### PR TITLE
Add LCM: DAG-based lossless context management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spare-paw
 
-A 24/7 personal AI agent running on a rooted Android phone via Termux, accessible through Telegram. Features multi-model routing via OpenRouter, shell and filesystem tools, scheduled tasks, voice transcription, and full-text search over conversation history. Cold starts in ~1 second.
+A 24/7 personal AI agent running on a rooted Android phone via Termux, accessible through Telegram. Features multi-model routing via OpenRouter, DAG-based lossless context management, shell and filesystem tools, scheduled tasks, voice transcription, and full-text search over conversation history. Cold starts in ~1 second.
 
 ## Features
 
@@ -11,6 +11,8 @@ A 24/7 personal AI agent running on a rooted Android phone via Termux, accessibl
 - **Voice messages** -- Groq Whisper transcription for Telegram voice notes
 - **Prompt files** -- loads `IDENTITY.md`, `USER.md`, and `SYSTEM.md` from `~/.spare-paw/` on every turn for personality, user preferences, and device context. Editable live without restart
 - **Full-text search** -- FTS5-backed search across all conversation history
+- **DAG-based lossless context management (LCM)** -- when conversation history grows beyond the fresh tail (32 messages), older messages are automatically summarized into leaf nodes (~8 messages each); when 4+ leaves accumulate they condense into higher-level summaries. Every original message is preserved and searchable. Summaries are assembled between the system prompt and fresh messages so the LLM retains awareness of older context. Compaction uses a cheap configurable model (default `google/gemini-3.1-flash-lite`) to keep costs low
+- **LCM tools** -- `lcm_grep` (search raw messages and compressed summaries via FTS5), `lcm_expand` (drill into a summary to recover original messages, token-capped), `lcm_describe` (get summaries for a time range)
 - **Sliding window context** -- token-budgeted context assembly with configurable window size and safety margin
 - **Message queue with backpressure** -- incoming messages queue while the bot is busy; typing indicator signals processing
 - **Heartbeat watchdog** -- detects event loop starvation and deadlocks, not just process crashes
@@ -73,7 +75,7 @@ A template is provided at `config.example.yaml`. Key sections:
 | `models` | Model slots: `default`, `smart`, `cron_default` |
 | `groq` | Groq API key for voice transcription |
 | `tavily` | Tavily API key for web search |
-| `context` | `max_messages`, `token_budget`, `safety_margin` |
+| `context` | `max_messages`, `token_budget`, `safety_margin`, `fresh_tail_count`, `leaf_chunk_size`, `condensed_min_fanout`, `summary_model` |
 | `tools` | Per-tool enable/disable, timeouts, allowed paths |
 | `mcp` | MCP client server connections |
 | `agent` | `max_tool_iterations`, `system_prompt` template |
@@ -86,6 +88,16 @@ models:
   default: "google/gemini-2.0-flash"
   smart: "anthropic/claude-sonnet-4"
   cron_default: "google/gemini-2.0-flash"
+```
+
+LCM (context compaction) settings:
+
+```yaml
+context:
+  fresh_tail_count: 32
+  leaf_chunk_size: 8
+  condensed_min_fanout: 4
+  summary_model: "google/gemini-3.1-flash-lite"
 ```
 
 ## Telegram Commands
@@ -122,6 +134,9 @@ All tools are exposed to the LLM as callable functions. Blocking tools run in a 
 | `spawn_agent` | Spawn a subagent for parallel work | `agent_type`: `researcher`, `coder`, or `analyst`; multiple can be spawned in one turn and are auto-grouped |
 | `list_agents` | List running/completed agents | Shows status, result preview, and per-agent token usage (prompt, completion, total) |
 | `cron_list` | List all scheduled tasks | Returns schedule, status, last run info |
+| `lcm_grep` | Search raw messages and compressed summaries | FTS5 full-text search across history and DAG summaries |
+| `lcm_expand` | Drill into a summary node | Recovers original messages under a summary, token-capped |
+| `lcm_describe` | Get summaries for a time range | Returns DAG summary nodes covering the specified period |
 
 ## MCP (Model Context Protocol)
 
@@ -149,7 +164,7 @@ MCP support requires `mcp>=1.26.0`, included in the package dependencies.
 Telegram Bot (python-telegram-bot)
   |
   v
-Context Manager (SQLite + FTS5 + sliding window)
+Context Manager (SQLite + FTS5 + DAG-based lossless context management with sliding window)
   |
   v
 Model Router (OpenRouter API, semaphore-serialized, retry with backoff)
@@ -182,6 +197,7 @@ Key design points:
 - Three agent archetypes (`researcher`, `coder`, `analyst`) each set appropriate tools and system prompt
 - Each agent tracks token usage (prompt, completion, total) from OpenRouter API responses
 - Token counting uses tiktoken with a configurable safety margin for non-OpenAI models
+- DAG compaction runs automatically after each turn: messages beyond the fresh tail are chunked into leaf summaries, and when enough leaves accumulate they condense into higher-level nodes. Schema v3 adds a `summary_nodes` table with FTS5 index. `assemble()` injects compressed history between the system prompt and fresh messages
 
 See [SPEC.md](SPEC.md) for the full specification including database schema, concurrency model, and design decisions.
 
@@ -223,6 +239,7 @@ src/spare_paw/
     tavily_search.py # Tavily Search API
     web_scrape.py    # URL fetch + parsing
     cron_tools.py    # Cron CRUD tools (create, edit, delete, list)
+    lcm_tools.py     # LCM tools (lcm_grep, lcm_expand, lcm_describe)
   cron/
     scheduler.py     # APScheduler setup
     executor.py      # Cron job execution

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,6 +20,10 @@ context:
   max_messages: 64        # sliding window size
   token_budget: 120000    # max tokens in assembled context
   safety_margin: 0.85     # multiply budget by this to account for tokenizer drift
+  fresh_tail_count: 32    # messages kept verbatim (not compacted)
+  leaf_chunk_size: 8      # messages per leaf summary
+  condensed_min_fanout: 4 # leaves needed before condensation
+  summary_model: "google/gemini-3.1-flash-lite"  # cheap model for compaction summaries
 
 tools:
   shell:

--- a/src/spare_paw/bot/handler.py
+++ b/src/spare_paw/bot/handler.py
@@ -221,7 +221,16 @@ async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         # 8. Ingest assistant response
         await ctx_module.ingest(conversation_id, "assistant", response_text)
 
-        # 9. Send response back via Telegram (chunked if needed)
+        # 9. Run LCM compaction in background (non-blocking)
+        summary_model = app_state.config.get(
+            "context.summary_model", "google/gemini-3.1-flash-lite"
+        )
+        asyncio.create_task(
+            ctx_module.compact(conversation_id, app_state.router_client, summary_model),
+            name="lcm-compact",
+        )
+
+        # 10. Send response back via Telegram (chunked if needed)
         await _send_response(update, response_text)
 
     finally:

--- a/src/spare_paw/context.py
+++ b/src/spare_paw/context.py
@@ -141,6 +141,26 @@ async def assemble(
 
     # Prepend system prompt
     messages = [{"role": "system", "content": system_prompt}]
+
+    # Inject summary nodes (compressed history) between system prompt and fresh messages
+    try:
+        async with db.execute(
+            """SELECT content FROM summary_nodes
+               WHERE conversation_id = ? AND parent_id IS NULL
+               ORDER BY created_at ASC""",
+            (conversation_id,),
+        ) as cursor:
+            summary_rows = await cursor.fetchall()
+
+        for srow in summary_rows:
+            messages.append({
+                "role": "system",
+                "content": f"[Compressed History]\n{srow['content']}",
+            })
+    except Exception:
+        # summary_nodes table may not exist in older schemas
+        pass
+
     messages.extend(selected)
 
     logger.debug(
@@ -208,3 +228,197 @@ async def new_conversation() -> str:
     await db.commit()
     logger.info("Created new conversation %s", conversation_id)
     return conversation_id
+
+
+# ---------------------------------------------------------------------------
+# LCM compaction engine
+# ---------------------------------------------------------------------------
+
+
+async def compact(
+    conversation_id: str,
+    router_client: Any,
+    model: str,
+) -> None:
+    """Run LCM compaction on a conversation.
+
+    1. Count total messages.
+    2. If total <= fresh_tail_count, return early.
+    3. Find messages not in the fresh tail and not already covered by summaries.
+    4. Chunk them and create leaf summaries.
+    5. If enough uncondensed leaves exist, condense them.
+    """
+    db = await get_db()
+    fresh_tail_count = config.get("context.fresh_tail_count", 32)
+    leaf_chunk_size = config.get("context.leaf_chunk_size", 8)
+
+    # 1. Count total messages
+    async with db.execute(
+        "SELECT COUNT(*) FROM messages WHERE conversation_id = ?",
+        (conversation_id,),
+    ) as cur:
+        total = (await cur.fetchone())[0]
+
+    # 2. If not enough messages, nothing to compact
+    if total <= fresh_tail_count:
+        return
+
+    # 3. Find messages NOT in the fresh tail
+    async with db.execute(
+        """SELECT id, role, content FROM messages
+           WHERE conversation_id = ?
+           ORDER BY created_at ASC""",
+        (conversation_id,),
+    ) as cur:
+        all_msgs = await cur.fetchall()
+
+    # Messages outside the fresh tail (oldest ones)
+    stale_msgs = all_msgs[: len(all_msgs) - fresh_tail_count]
+
+    # Find message IDs already covered by existing summary nodes
+    async with db.execute(
+        "SELECT source_msg_ids FROM summary_nodes WHERE conversation_id = ? AND depth = 0",
+        (conversation_id,),
+    ) as cur:
+        rows = await cur.fetchall()
+
+    covered_ids: set[str] = set()
+    for row in rows:
+        covered_ids.update(json.loads(row["source_msg_ids"]))
+
+    # Filter to uncovered messages only
+    uncovered = [
+        {"id": m["id"], "role": m["role"], "content": m["content"]}
+        for m in stale_msgs
+        if m["id"] not in covered_ids
+    ]
+
+    if not uncovered:
+        # Still check if condensation is needed
+        await _condense_summaries(conversation_id, router_client, model)
+        return
+
+    # 4. Chunk and create leaf summaries
+    for i in range(0, len(uncovered), leaf_chunk_size):
+        chunk = uncovered[i : i + leaf_chunk_size]
+        await _create_leaf_summary(conversation_id, chunk, router_client, model)
+
+    # 5. Condense if enough uncondensed leaves
+    await _condense_summaries(conversation_id, router_client, model)
+
+
+async def _create_leaf_summary(
+    conversation_id: str,
+    messages: list[dict],
+    router_client: Any,
+    model: str,
+) -> str:
+    """Summarize a chunk of messages into a leaf summary node (depth=0).
+
+    Returns the new node_id.
+    """
+    # Build the summarization prompt
+    formatted = "\n".join(
+        f"{m['role']}: {m['content']}" for m in messages
+    )
+    prompt = (
+        "Summarize the following conversation messages concisely, "
+        "preserving key facts, decisions, and context:\n\n" + formatted
+    )
+
+    # Call the LLM
+    response = await router_client.chat(
+        messages=[{"role": "user", "content": prompt}],
+        model=model,
+    )
+    summary_text = response["choices"][0]["message"]["content"]
+
+    # Store in DB
+    db = await get_db()
+    node_id = uuid.uuid4().hex
+    token_count = count_tokens(summary_text)
+    now = datetime.now(timezone.utc).isoformat()
+    source_ids = json.dumps([m["id"] for m in messages])
+
+    await db.execute(
+        """INSERT INTO summary_nodes
+           (id, conversation_id, parent_id, depth, content, token_count, source_msg_ids, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (node_id, conversation_id, None, 0, summary_text, token_count, source_ids, now),
+    )
+    await db.commit()
+
+    logger.debug(
+        "Created leaf summary %s (%d tokens) for conversation %s",
+        node_id, token_count, conversation_id,
+    )
+    return node_id
+
+
+async def _condense_summaries(
+    conversation_id: str,
+    router_client: Any,
+    model: str,
+) -> None:
+    """Condense uncondensed leaf nodes into a higher-level summary (depth=1).
+
+    Only runs when there are >= condensed_min_fanout orphan leaf nodes.
+    """
+    db = await get_db()
+    condensed_min_fanout = config.get("context.condensed_min_fanout", 4)
+
+    # Fetch orphan leaf nodes (depth=0, no parent)
+    async with db.execute(
+        """SELECT id, content FROM summary_nodes
+           WHERE conversation_id = ? AND depth = 0 AND parent_id IS NULL
+           ORDER BY created_at ASC""",
+        (conversation_id,),
+    ) as cur:
+        leaves = await cur.fetchall()
+
+    if len(leaves) < condensed_min_fanout:
+        return
+
+    # Build condensation prompt
+    formatted = "\n\n".join(
+        f"Summary {i + 1}: {leaf['content']}" for i, leaf in enumerate(leaves)
+    )
+    prompt = (
+        "Condense the following conversation summaries into a single, "
+        "higher-level summary preserving all key facts and context:\n\n" + formatted
+    )
+
+    # Call the LLM
+    response = await router_client.chat(
+        messages=[{"role": "user", "content": prompt}],
+        model=model,
+    )
+    condensed_text = response["choices"][0]["message"]["content"]
+
+    # Store condensed node
+    node_id = uuid.uuid4().hex
+    token_count = count_tokens(condensed_text)
+    now = datetime.now(timezone.utc).isoformat()
+    leaf_ids = [leaf["id"] for leaf in leaves]
+    source_ids = json.dumps(leaf_ids)
+
+    await db.execute(
+        """INSERT INTO summary_nodes
+           (id, conversation_id, parent_id, depth, content, token_count, source_msg_ids, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (node_id, conversation_id, None, 1, condensed_text, token_count, source_ids, now),
+    )
+
+    # Update leaf nodes to point to the new parent
+    for leaf_id in leaf_ids:
+        await db.execute(
+            "UPDATE summary_nodes SET parent_id = ? WHERE id = ?",
+            (node_id, leaf_id),
+        )
+
+    await db.commit()
+
+    logger.debug(
+        "Condensed %d leaves into node %s (depth=1) for conversation %s",
+        len(leaves), node_id, conversation_id,
+    )

--- a/src/spare_paw/db.py
+++ b/src/spare_paw/db.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 DB_DIR = Path.home() / ".spare-paw"
 DB_PATH = DB_DIR / "spare-paw.db"
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 SCHEMA_V1 = """\
 CREATE TABLE IF NOT EXISTS messages (
@@ -103,6 +103,40 @@ CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
 END;
 """
 
+SCHEMA_V3 = """\
+CREATE TABLE IF NOT EXISTS summary_nodes (
+    id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    parent_id TEXT,
+    depth INTEGER NOT NULL DEFAULT 0,
+    content TEXT NOT NULL,
+    token_count INTEGER NOT NULL,
+    source_msg_ids TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_summary_nodes_conversation
+    ON summary_nodes(conversation_id, depth, created_at);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS summary_nodes_fts
+    USING fts5(content, content=summary_nodes, content_rowid=rowid);
+
+CREATE TRIGGER IF NOT EXISTS summary_nodes_ai AFTER INSERT ON summary_nodes BEGIN
+    INSERT INTO summary_nodes_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS summary_nodes_ad AFTER DELETE ON summary_nodes BEGIN
+    INSERT INTO summary_nodes_fts(summary_nodes_fts, rowid, content)
+        VALUES('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS summary_nodes_au AFTER UPDATE ON summary_nodes BEGIN
+    INSERT INTO summary_nodes_fts(summary_nodes_fts, rowid, content)
+        VALUES('delete', old.rowid, old.content);
+    INSERT INTO summary_nodes_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+"""
+
 # ---- Singleton connection ----
 
 _connection: aiosqlite.Connection | None = None
@@ -147,6 +181,13 @@ async def init_db() -> None:
         await _set_user_version(conn, 2)
         await conn.commit()
         logger.info("Database schema v2 applied")
+
+    if version < 3:
+        logger.info("Migrating database to schema v3 (summary_nodes)")
+        await conn.executescript(SCHEMA_V3)
+        await _set_user_version(conn, 3)
+        await conn.commit()
+        logger.info("Database schema v3 applied")
 
 
 async def close_db() -> None:

--- a/src/spare_paw/gateway.py
+++ b/src/spare_paw/gateway.py
@@ -143,7 +143,7 @@ async def _async_main() -> None:
     # 9. Register tools (needs app_state for cron_tools)
     config_data = config.data
 
-    from spare_paw.tools import code, cron_tools, files, memory, shell, subagent, tavily_search, web_scrape
+    from spare_paw.tools import code, cron_tools, files, lcm_tools, memory, shell, subagent, tavily_search, web_scrape
     from spare_paw.tools.custom_tools import load_custom_tools, register_meta_tools
 
     shell.register(tool_registry, config_data)
@@ -156,6 +156,7 @@ async def _async_main() -> None:
     load_custom_tools(tool_registry, executor)
     register_meta_tools(tool_registry, config_data, app_state)
     subagent.register(tool_registry, config_data, app_state)
+    lcm_tools.register(tool_registry, config_data)
 
     # Inline read_logs tool
     async def _read_logs(count: int = 50) -> str:

--- a/src/spare_paw/tools/lcm_tools.py
+++ b/src/spare_paw/tools/lcm_tools.py
@@ -1,0 +1,270 @@
+"""LCM (Lossless Context Management) tools — lcm_grep, lcm_expand, lcm_describe.
+
+Provide search, expansion, and description capabilities over the DAG-based
+summary_nodes and raw messages tables.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from spare_paw.context import count_tokens
+from spare_paw.db import get_db
+
+logger = logging.getLogger(__name__)
+
+# -- Schemas ---------------------------------------------------------------
+
+LCM_GREP_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": "FTS5 search query to find in messages and summaries",
+        },
+        "limit": {
+            "type": "integer",
+            "description": "Maximum number of results to return (default 10)",
+        },
+    },
+    "required": ["query"],
+}
+
+LCM_EXPAND_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "summary_id": {
+            "type": "string",
+            "description": "The ID of the summary node to expand",
+        },
+        "max_tokens": {
+            "type": "integer",
+            "description": "Maximum tokens to return (default 4000)",
+        },
+    },
+    "required": ["summary_id"],
+}
+
+LCM_DESCRIBE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "conversation_id": {
+            "type": "string",
+            "description": "Filter by conversation ID (optional)",
+        },
+        "start_time": {
+            "type": "string",
+            "description": "ISO 8601 start time for the range (optional)",
+        },
+        "end_time": {
+            "type": "string",
+            "description": "ISO 8601 end time for the range (optional)",
+        },
+    },
+}
+
+# -- Handlers --------------------------------------------------------------
+
+
+async def _handle_lcm_grep(query: str, limit: int = 10) -> str:
+    """Search both messages and summary_nodes via FTS5."""
+    db = await get_db()
+    results: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    # Search messages_fts
+    async with db.execute(
+        """SELECT m.id, m.role, m.content, m.created_at
+           FROM messages_fts fts
+           JOIN messages m ON m.rowid = fts.rowid
+           WHERE messages_fts MATCH ?
+           ORDER BY rank
+           LIMIT ?""",
+        (query, limit),
+    ) as cursor:
+        rows = await cursor.fetchall()
+
+    for row in rows:
+        key = row["id"]
+        if key not in seen:
+            seen.add(key)
+            results.append({
+                "source": "message",
+                "content": row["content"],
+                "role": row["role"],
+                "created_at": row["created_at"],
+            })
+
+    # Search summary_nodes_fts
+    async with db.execute(
+        """SELECT s.id, s.content, s.created_at
+           FROM summary_nodes_fts fts
+           JOIN summary_nodes s ON s.rowid = fts.rowid
+           WHERE summary_nodes_fts MATCH ?
+           ORDER BY rank
+           LIMIT ?""",
+        (query, limit),
+    ) as cursor:
+        rows = await cursor.fetchall()
+
+    for row in rows:
+        key = row["id"]
+        if key not in seen:
+            seen.add(key)
+            results.append({
+                "source": "summary",
+                "content": row["content"],
+                "role": "summary",
+                "created_at": row["created_at"],
+            })
+
+    return json.dumps({"results": results})
+
+
+async def _handle_lcm_expand(summary_id: str, max_tokens: int = 4000) -> str:
+    """Return the original messages that a summary was built from, capped at max_tokens."""
+    db = await get_db()
+
+    # Fetch the summary node
+    async with db.execute(
+        "SELECT * FROM summary_nodes WHERE id = ?",
+        (summary_id,),
+    ) as cursor:
+        node = await cursor.fetchone()
+
+    if node is None:
+        return json.dumps({"error": f"Summary node not found: {summary_id}"})
+
+    source_msg_ids = json.loads(node["source_msg_ids"])
+    total_source_messages = len(source_msg_ids)
+
+    if not source_msg_ids:
+        return json.dumps({
+            "summary_id": summary_id,
+            "messages": [],
+            "truncated": False,
+            "total_source_messages": 0,
+        })
+
+    # Fetch messages by IDs, ordered by created_at
+    placeholders = ",".join("?" for _ in source_msg_ids)
+    async with db.execute(
+        f"""SELECT role, content, created_at
+            FROM messages
+            WHERE id IN ({placeholders})
+            ORDER BY created_at""",
+        source_msg_ids,
+    ) as cursor:
+        rows = await cursor.fetchall()
+
+    # Walk through messages, accumulating tokens
+    messages: list[dict[str, str]] = []
+    token_total = 0
+    truncated = False
+
+    for row in rows:
+        tokens = count_tokens(row["content"])
+        if token_total + tokens > max_tokens:
+            truncated = True
+            break
+        token_total += tokens
+        messages.append({
+            "role": row["role"],
+            "content": row["content"],
+            "created_at": row["created_at"],
+        })
+
+    return json.dumps({
+        "summary_id": summary_id,
+        "messages": messages,
+        "truncated": truncated,
+        "total_source_messages": total_source_messages,
+    })
+
+
+async def _handle_lcm_describe(
+    conversation_id: str | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+) -> str:
+    """Return summaries covering a time range."""
+    db = await get_db()
+
+    conditions: list[str] = []
+    params: list[str] = []
+
+    if conversation_id is not None:
+        conditions.append("conversation_id = ?")
+        params.append(conversation_id)
+    if start_time is not None:
+        conditions.append("created_at >= ?")
+        params.append(start_time)
+    if end_time is not None:
+        conditions.append("created_at <= ?")
+        params.append(end_time)
+
+    where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+    async with db.execute(
+        f"""SELECT id, conversation_id, parent_id, depth, content,
+                   token_count, source_msg_ids, created_at
+            FROM summary_nodes
+            WHERE {where_clause}
+            ORDER BY created_at""",
+        params,
+    ) as cursor:
+        rows = await cursor.fetchall()
+
+    summaries = [
+        {
+            "id": row["id"],
+            "conversation_id": row["conversation_id"],
+            "parent_id": row["parent_id"],
+            "depth": row["depth"],
+            "content": row["content"],
+            "token_count": row["token_count"],
+            "source_msg_ids": json.loads(row["source_msg_ids"]),
+            "created_at": row["created_at"],
+        }
+        for row in rows
+    ]
+
+    return json.dumps({"summaries": summaries, "count": len(summaries)})
+
+
+# -- Registration ----------------------------------------------------------
+
+
+def register(registry: Any, config: dict[str, Any]) -> None:
+    """Register LCM tools."""
+    registry.register(
+        name="lcm_grep",
+        description=(
+            "Search conversation history and compressed summaries for a query. "
+            "Returns results from both raw messages and summary nodes."
+        ),
+        parameters_schema=LCM_GREP_SCHEMA,
+        handler=_handle_lcm_grep,
+        run_in_executor=False,
+    )
+
+    registry.register(
+        name="lcm_expand",
+        description=(
+            "Expand a compressed history summary to see the original messages "
+            "it was built from. Use when you need more detail than a summary provides."
+        ),
+        parameters_schema=LCM_EXPAND_SCHEMA,
+        handler=_handle_lcm_expand,
+        run_in_executor=False,
+    )
+
+    registry.register(
+        name="lcm_describe",
+        description="Get summaries of conversation history for a given time range.",
+        parameters_schema=LCM_DESCRIBE_SCHEMA,
+        handler=_handle_lcm_describe,
+        run_in_executor=False,
+    )

--- a/tests/test_lcm.py
+++ b/tests/test_lcm.py
@@ -1,0 +1,423 @@
+"""Tests for LCM (Lossless Context Management) DAG-based memory system.
+
+Covers schema v3 (summary_nodes table + FTS), compaction engine, modified
+assemble() with summary injection, and LCM tools (lcm_grep, lcm_expand).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+import aiosqlite
+
+import spare_paw.db as db_mod
+from spare_paw.context import ingest, assemble, new_conversation
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def _init_db(tmp_path):
+    """Create a temp DB with all schemas (v1 + v2 + v3) applied."""
+    db_path = tmp_path / "test.db"
+
+    conn = await aiosqlite.connect(str(db_path))
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("PRAGMA journal_mode = WAL")
+    await conn.execute("PRAGMA foreign_keys = ON")
+
+    # Patch the singleton
+    db_mod._connection = conn
+
+    # Apply all schemas
+    await conn.executescript(db_mod.SCHEMA_V1)
+    await conn.executescript(db_mod.SCHEMA_V2)
+    await conn.executescript(db_mod.SCHEMA_V3)
+    await conn.execute(f"PRAGMA user_version = {db_mod.CURRENT_SCHEMA_VERSION}")
+    await conn.commit()
+
+    yield conn
+
+    await conn.close()
+    db_mod._connection = None
+
+
+async def _insert_summary_node(
+    conn,
+    conversation_id: str,
+    content: str,
+    *,
+    node_id: str | None = None,
+    parent_id: str | None = None,
+    depth: int = 0,
+    token_count: int = 10,
+    source_msg_ids: list[str] | None = None,
+) -> str:
+    """Helper to insert a summary_node directly."""
+    node_id = node_id or uuid.uuid4().hex
+    now = datetime.now(timezone.utc).isoformat()
+    source_ids_json = json.dumps(source_msg_ids or [])
+
+    await conn.execute(
+        """INSERT INTO summary_nodes
+           (id, conversation_id, parent_id, depth, content, token_count, source_msg_ids, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (node_id, conversation_id, parent_id, depth, content, token_count, source_ids_json, now),
+    )
+    await conn.commit()
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# Schema v3 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schema_v3_creates_summary_nodes_table(_init_db):
+    """After init_db with v3, summary_nodes table should exist."""
+    conn = _init_db
+
+    async with conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+    ) as cur:
+        tables = {row[0] for row in await cur.fetchall()}
+
+    assert "summary_nodes" in tables
+
+
+@pytest.mark.asyncio
+async def test_summary_nodes_fts(_init_db):
+    """Inserting into summary_nodes should populate the FTS index via triggers."""
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    await _insert_summary_node(
+        conn, conv_id, "The user discussed quantum computing and entanglement"
+    )
+
+    async with conn.execute(
+        "SELECT content FROM summary_nodes_fts WHERE summary_nodes_fts MATCH 'quantum'"
+    ) as cur:
+        rows = await cur.fetchall()
+
+    assert len(rows) == 1
+    assert "quantum" in rows[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Compaction tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_router_client(summary_text: str = "This is a summary.") -> MagicMock:
+    """Create a mock router client that returns a canned summary response (dict format)."""
+    client = MagicMock()
+    mock_response = {
+        "choices": [{"message": {"content": summary_text}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    client.chat = AsyncMock(return_value=mock_response)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_compact_creates_leaf_summaries(_init_db):
+    """When enough messages exist beyond the fresh tail, compact() creates leaf nodes."""
+    from spare_paw.config import config as config_mod
+    from spare_paw.context import compact
+
+    # Use a small fresh tail so 30 messages trigger compaction
+    config_mod.set_override("context.fresh_tail_count", 10)
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Ingest enough messages to trigger compaction (well beyond fresh tail of 10)
+    for i in range(30):
+        await ingest(conv_id, "user", f"Message number {i} about various topics")
+
+    mock_client = _make_mock_router_client("Summary of old messages.")
+
+    await compact(conv_id, mock_client, "test-model")
+
+    # Verify leaf summary nodes were created
+    async with conn.execute(
+        "SELECT * FROM summary_nodes WHERE conversation_id = ? AND depth = 0",
+        (conv_id,),
+    ) as cur:
+        leaves = await cur.fetchall()
+
+    assert len(leaves) > 0
+    assert leaves[0]["content"] == "Summary of old messages."
+    # The LLM should have been called at least once
+    assert mock_client.chat.call_count >= 1
+
+    # Clean up override
+    config_mod.set_override("context.fresh_tail_count", 32)
+
+
+@pytest.mark.asyncio
+async def test_compact_does_nothing_below_threshold(_init_db):
+    """When message count is below threshold, compact() does nothing."""
+    from spare_paw.context import compact
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Only a few messages — not enough to trigger compaction
+    for i in range(3):
+        await ingest(conv_id, "user", f"Short message {i}")
+
+    mock_client = _make_mock_router_client()
+
+    await compact(conv_id, mock_client, "test-model")
+
+    # No summary nodes should be created
+    async with conn.execute(
+        "SELECT COUNT(*) FROM summary_nodes WHERE conversation_id = ?",
+        (conv_id,),
+    ) as cur:
+        count = (await cur.fetchone())[0]
+
+    assert count == 0
+    # LLM should not have been called
+    assert mock_client.chat.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_condense_creates_higher_level_node(_init_db):
+    """When 4+ leaf nodes exist, they get condensed into a depth=1 node."""
+    from spare_paw.config import config as config_mod
+    from spare_paw.context import compact
+
+    config_mod.set_override("context.fresh_tail_count", 5)
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Pre-create 4 leaf summary nodes to trigger condensation
+    leaf_ids = []
+    for i in range(4):
+        lid = await _insert_summary_node(
+            conn, conv_id, f"Leaf summary {i} about topic {i}",
+            depth=0, source_msg_ids=[f"msg_{i}"],
+        )
+        leaf_ids.append(lid)
+
+    # Need enough messages so compact runs past the fresh tail check
+    for i in range(20):
+        await ingest(conv_id, "user", f"Message {i}")
+
+    mock_client = _make_mock_router_client("Condensed summary of all leaves.")
+
+    await compact(conv_id, mock_client, "test-model")
+
+    # Check for higher-level node (depth >= 1)
+    async with conn.execute(
+        "SELECT * FROM summary_nodes WHERE conversation_id = ? AND depth >= 1",
+        (conv_id,),
+    ) as cur:
+        condensed = await cur.fetchall()
+
+    assert len(condensed) >= 1
+
+    # Clean up override
+    config_mod.set_override("context.fresh_tail_count", 32)
+
+
+@pytest.mark.asyncio
+async def test_compact_preserves_fresh_tail(_init_db):
+    """The last N messages (fresh tail) should never be compacted."""
+    from spare_paw.config import config as config_mod
+    from spare_paw.context import compact
+
+    config_mod.set_override("context.fresh_tail_count", 10)
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Ingest messages — the most recent ones should remain untouched
+    msg_ids = []
+    for i in range(30):
+        mid = await ingest(conv_id, "user", f"Message {i} with content")
+        msg_ids.append(mid)
+
+    mock_client = _make_mock_router_client("Summary of older messages.")
+
+    await compact(conv_id, mock_client, "test-model")
+
+    # Fetch all source_msg_ids from summary nodes
+    async with conn.execute(
+        "SELECT source_msg_ids FROM summary_nodes WHERE conversation_id = ?",
+        (conv_id,),
+    ) as cur:
+        rows = await cur.fetchall()
+
+    compacted_ids: set[str] = set()
+    for row in rows:
+        compacted_ids.update(json.loads(row["source_msg_ids"]))
+
+    # The newest messages should NOT appear in any summary source_msg_ids
+    # (they are the "fresh tail" that stays unconsolidated)
+    newest_ids = set(msg_ids[-10:])  # last 10 = fresh tail, should not be compacted
+    assert compacted_ids.isdisjoint(newest_ids), (
+        "Fresh tail messages should not be compacted"
+    )
+
+    # Clean up override
+    config_mod.set_override("context.fresh_tail_count", 32)
+
+
+# ---------------------------------------------------------------------------
+# Assembly tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assemble_includes_summaries(_init_db):
+    """When summary nodes exist, assemble() includes them between system prompt and fresh messages."""
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Insert summary nodes
+    await _insert_summary_node(
+        conn, conv_id, "Previously, the user discussed Python and databases.",
+        depth=1, token_count=10,
+    )
+
+    # Add some fresh messages
+    await ingest(conv_id, "user", "What were we talking about?")
+    await ingest(conv_id, "assistant", "Let me check our history.")
+
+    messages = await assemble(conv_id, "You are a helpful assistant.")
+
+    # System prompt first
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "You are a helpful assistant."
+
+    # Should contain a compressed history entry somewhere before fresh messages
+    contents = [m["content"] for m in messages]
+    has_summary = any("[Compressed History]" in c for c in contents)
+    assert has_summary, "assemble() should include summary nodes as compressed history"
+
+    # Fresh messages should still be present
+    assert any("What were we talking about?" in c for c in contents)
+    assert any("Let me check our history." in c for c in contents)
+
+
+@pytest.mark.asyncio
+async def test_assemble_with_no_summaries_unchanged(_init_db):
+    """When no summary nodes exist, assemble() works exactly as before."""
+    conv_id = await new_conversation()
+    await ingest(conv_id, "user", "Hello")
+    await ingest(conv_id, "assistant", "Hi there!")
+
+    messages = await assemble(conv_id, "You are a helpful assistant.")
+
+    assert messages[0] == {"role": "system", "content": "You are a helpful assistant."}
+    assert messages[1] == {"role": "user", "content": "Hello"}
+    assert messages[2] == {"role": "assistant", "content": "Hi there!"}
+    assert len(messages) == 3
+
+    # No compressed history markers
+    assert not any("[Compressed History]" in m["content"] for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# LCM tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lcm_grep_searches_summaries(_init_db):
+    """lcm_grep should find content in summary nodes via FTS5."""
+    from spare_paw.tools.lcm_tools import _handle_lcm_grep
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Insert a summary node with specific content
+    await _insert_summary_node(
+        conn, conv_id, "Discussed machine learning and neural networks extensively"
+    )
+
+    # Also insert a regular message with different content
+    await ingest(conv_id, "user", "Tell me about neural networks")
+
+    result_json = await _handle_lcm_grep(query="neural networks")
+    result = json.loads(result_json)
+
+    # Should find results from both messages and summary nodes
+    assert len(result.get("results", [])) >= 1
+
+
+@pytest.mark.asyncio
+async def test_lcm_expand_returns_source_messages(_init_db):
+    """lcm_expand should return the original messages that a summary was built from."""
+    from spare_paw.tools.lcm_tools import _handle_lcm_expand
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Create source messages
+    msg_id1 = await ingest(conv_id, "user", "First message about Python")
+    msg_id2 = await ingest(conv_id, "assistant", "Python is a great language")
+    msg_id3 = await ingest(conv_id, "user", "Tell me about decorators")
+
+    # Create a summary referencing those messages
+    summary_id = await _insert_summary_node(
+        conn, conv_id, "Discussion about Python and decorators",
+        source_msg_ids=[msg_id1, msg_id2, msg_id3],
+    )
+
+    result_json = await _handle_lcm_expand(summary_id=summary_id)
+    result = json.loads(result_json)
+
+    # Should return the source messages
+    messages = result.get("messages", [])
+    assert len(messages) == 3
+    contents = [m["content"] for m in messages]
+    assert "First message about Python" in contents
+    assert "Python is a great language" in contents
+    assert "Tell me about decorators" in contents
+
+
+@pytest.mark.asyncio
+async def test_lcm_expand_respects_token_limit(_init_db):
+    """lcm_expand should cap output at max_tokens."""
+    from spare_paw.tools.lcm_tools import _handle_lcm_expand
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Create several long messages
+    msg_ids = []
+    for i in range(10):
+        mid = await ingest(
+            conv_id, "user",
+            f"This is a fairly long message number {i} with lots of words to consume tokens. " * 20,
+        )
+        msg_ids.append(mid)
+
+    summary_id = await _insert_summary_node(
+        conn, conv_id, "Summary of many long messages",
+        source_msg_ids=msg_ids,
+    )
+
+    # Request with a very small token limit
+    result_json = await _handle_lcm_expand(summary_id=summary_id, max_tokens=100)
+    result = json.loads(result_json)
+
+    # Should return fewer messages than the total (capped by tokens)
+    messages = result.get("messages", [])
+    assert len(messages) < 10, "lcm_expand should cap output when max_tokens is small"
+    assert result.get("truncated", False) is True


### PR DESCRIPTION
## Summary

- **DAG-based memory compaction** — when conversation history grows beyond the fresh tail (32 messages), older messages are automatically summarized into leaf nodes (~8 messages each). When 4+ leaves accumulate, they're condensed into higher-level summaries. Every original message is preserved and searchable via FTS5.
- **Compaction runs as background task** after each message (non-blocking), using a cheap model (`google/gemini-3.1-flash-lite`) to keep costs low.
- **Modified context assembly** — `assemble()` now injects `[Compressed History]` summaries between the system prompt and fresh messages, giving the LLM awareness of older conversation context.
- **3 new LCM tools** — `lcm_grep` (search messages + summaries), `lcm_expand` (drill into summary to recover originals), `lcm_describe` (summaries for a time range).
- **Schema v3** — `summary_nodes` table with FTS5 index, automatic migration from v2.

## Test plan

- [x] 11 new LCM tests (schema, compaction, assembly, tools)
- [x] Full suite passing (ruff clean, all tests green)
- [x] Deployed to Termux phone, bot starts with schema v3 migration
- [x] Test compaction by sending 40+ messages and verifying summaries are created
- [x] Test lcm_grep/lcm_expand via Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)