### PR TITLE
Add Telegram command menu and document one-shot reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A 24/7 personal AI agent running on a rooted Android phone via Termux, accessibl
 - **Multi-model routing** -- configure model slots (default, smart, cron) via OpenRouter; switch on the fly
 - **Tool use** -- shell commands, file operations, web search, web scraping, cron management; all exposed as LLM function calls
 - **Scheduled tasks (cron)** -- create, edit, pause, resume, and manage recurring AI tasks with per-cron model selection
+- **One-shot reminders** -- ask the bot to remind you of something in X minutes/hours; it creates a cron that fires once and auto-deletes itself (e.g. "remind me to call John in 30 minutes")
 - **Photo/image support** -- send photos via Telegram; they are base64-encoded and forwarded to the model as multimodal vision messages. Caption is used as the prompt (defaults to "What do you see in this image?")
 - **Voice messages** -- Groq Whisper transcription for Telegram voice notes
 - **Prompt files** -- loads `IDENTITY.md`, `USER.md`, and `SYSTEM.md` from `~/.spare-paw/` on every turn for personality, user preferences, and device context. Editable live without restart

--- a/src/spare_paw/gateway.py
+++ b/src/spare_paw/gateway.py
@@ -325,6 +325,19 @@ async def _async_main() -> None:
 
     # 16. Start the bot
     await application.initialize()
+
+    # Set Telegram bot command menu
+    from telegram import BotCommand
+    await application.bot.set_my_commands([
+        BotCommand("cron", "Manage scheduled tasks (list, remove, pause, resume, info)"),
+        BotCommand("config", "Show or change runtime config"),
+        BotCommand("status", "Uptime, memory, DB size, active crons"),
+        BotCommand("search", "Full-text search over conversation history"),
+        BotCommand("forget", "Start a new conversation"),
+        BotCommand("model", "Switch the active model"),
+        BotCommand("mcp", "List connected MCP servers and tools"),
+    ])
+
     await application.start()
 
     # 17. Start message queue processor (must be after initialize/start)


### PR DESCRIPTION
## Summary

- **Telegram command menu** — calls `set_my_commands()` at startup so users see a clickable command list when tapping `/` in chat. Lists: cron, config, status, search, forget, model, mcp.
- **Document one-shot reminders** — added to README features list. The bot can create reminders that fire once and auto-delete (e.g. "remind me to call John in 30 minutes").

## Test plan

- [x] Deployed to phone, command menu visible in Telegram
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)