### PR TITLE
Redact secrets from logs and shell output

### DIFF
--- a/src/spare_paw/gateway.py
+++ b/src/spare_paw/gateway.py
@@ -19,6 +19,7 @@ from telegram.ext import Application
 
 from spare_paw.config import Config, config
 from spare_paw.db import close_db, init_db
+from spare_paw.util.redact import redact_secrets
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,13 @@ class AppState:
 app_state: AppState | None = None
 
 
+class _RedactingFormatter(logging.Formatter):
+    """Logging formatter that redacts secrets from every log message."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        return redact_secrets(super().format(record))
+
+
 def _setup_logging() -> None:
     """Configure rotating file + stderr logging."""
     LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -60,6 +68,11 @@ def _setup_logging() -> None:
     # Clear existing handlers to avoid duplicates on reload
     root_logger.handlers.clear()
 
+    formatter = _RedactingFormatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
     # Rotating file handler
     file_handler = RotatingFileHandler(
         LOG_DIR / "spare-paw.log",
@@ -68,17 +81,13 @@ def _setup_logging() -> None:
         encoding="utf-8",
     )
     file_handler.setLevel(level)
-    file_formatter = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    file_handler.setFormatter(file_formatter)
+    file_handler.setFormatter(formatter)
     root_logger.addHandler(file_handler)
 
     # Stderr handler
     stderr_handler = logging.StreamHandler()
     stderr_handler.setLevel(level)
-    stderr_handler.setFormatter(file_formatter)
+    stderr_handler.setFormatter(formatter)
     root_logger.addHandler(stderr_handler)
 
 

--- a/src/spare_paw/tools/shell.py
+++ b/src/spare_paw/tools/shell.py
@@ -57,7 +57,7 @@ def execute_shell(
     This is a **synchronous** function — it will be dispatched to a
     ``ProcessPoolExecutor`` by the tool registry.
     """
-    logger.info("shell: executing (timeout=%ds): %s", timeout, redact_secrets(command[:200]))
+    logger.info("shell: executing (timeout=%ds): %s", timeout, redact_secrets(command)[:200])
 
     try:
         proc = subprocess.run(
@@ -86,7 +86,7 @@ def execute_shell(
         )
 
     except subprocess.TimeoutExpired:
-        logger.warning("shell: command timed out after %ds: %s", timeout, redact_secrets(command[:200]))
+        logger.warning("shell: command timed out after %ds: %s", timeout, redact_secrets(command)[:200])
         return json.dumps(
             {
                 "error": f"Command timed out after {timeout}s",

--- a/src/spare_paw/tools/shell.py
+++ b/src/spare_paw/tools/shell.py
@@ -12,6 +12,8 @@ import logging
 import subprocess
 from typing import TYPE_CHECKING, Any
 
+from spare_paw.util.redact import redact_secrets
+
 if TYPE_CHECKING:
     from spare_paw.tools.registry import ToolRegistry
 
@@ -55,7 +57,7 @@ def execute_shell(
     This is a **synchronous** function — it will be dispatched to a
     ``ProcessPoolExecutor`` by the tool registry.
     """
-    logger.info("shell: executing (timeout=%ds): %s", timeout, command[:200])
+    logger.info("shell: executing (timeout=%ds): %s", timeout, redact_secrets(command[:200]))
 
     try:
         proc = subprocess.run(
@@ -84,7 +86,7 @@ def execute_shell(
         )
 
     except subprocess.TimeoutExpired:
-        logger.warning("shell: command timed out after %ds: %s", timeout, command[:200])
+        logger.warning("shell: command timed out after %ds: %s", timeout, redact_secrets(command[:200]))
         return json.dumps(
             {
                 "error": f"Command timed out after {timeout}s",

--- a/src/spare_paw/util/redact.py
+++ b/src/spare_paw/util/redact.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import re
 
 _PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"sk-[a-zA-Z0-9-]{20,}"),
-    re.compile(r"ghp_[a-zA-Z0-9]{36}"),
-    re.compile(r"Bearer [a-zA-Z0-9._-]+"),
-    re.compile(r"(?i)(password|token|api_key)=\S+"),
+    re.compile(r"sk-[a-zA-Z0-9-]{20,}"),                        # OpenAI / OpenRouter
+    re.compile(r"ghp_[a-zA-Z0-9]{36}"),                          # GitHub PAT
+    re.compile(r"gsk_[a-zA-Z0-9]{20,}"),                         # Groq
+    re.compile(r"tvly-[a-zA-Z0-9]{20,}"),                        # Tavily
+    re.compile(r"\b\d{8,10}:[A-Za-z0-9_-]{35}\b"),               # Telegram bot token
+    re.compile(r"Bearer [a-zA-Z0-9._-]{20,}"),                   # Bearer (min 20 chars)
+    re.compile(r"(?i)(password|secret|token|api_?key)=\S+"),     # query params
 ]
 
 _REPLACEMENT = "[REDACTED]"

--- a/src/spare_paw/util/redact.py
+++ b/src/spare_paw/util/redact.py
@@ -9,7 +9,7 @@ _PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"ghp_[a-zA-Z0-9]{36}"),                          # GitHub PAT
     re.compile(r"gsk_[a-zA-Z0-9]{20,}"),                         # Groq
     re.compile(r"tvly-[a-zA-Z0-9]{20,}"),                        # Tavily
-    re.compile(r"\b\d{8,10}:[A-Za-z0-9_-]{35}\b"),               # Telegram bot token
+    re.compile(r"\d{8,10}:[A-Za-z0-9_-]{35}"),                    # Telegram bot token
     re.compile(r"Bearer [a-zA-Z0-9._-]{20,}"),                   # Bearer (min 20 chars)
     re.compile(r"(?i)(password|secret|token|api_?key)=\S+"),     # query params
 ]

--- a/src/spare_paw/util/redact.py
+++ b/src/spare_paw/util/redact.py
@@ -1,0 +1,21 @@
+"""Utilities for redacting secrets from log output."""
+
+from __future__ import annotations
+
+import re
+
+_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"sk-[a-zA-Z0-9-]{20,}"),
+    re.compile(r"ghp_[a-zA-Z0-9]{36}"),
+    re.compile(r"Bearer [a-zA-Z0-9._-]+"),
+    re.compile(r"(?i)(password|token|api_key)=\S+"),
+]
+
+_REPLACEMENT = "[REDACTED]"
+
+
+def redact_secrets(text: str) -> str:
+    """Replace known secret patterns in *text* with ``[REDACTED]``."""
+    for pattern in _PATTERNS:
+        text = pattern.sub(_REPLACEMENT, text)
+    return text

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -21,10 +21,30 @@ class TestRedactSecrets:
                 "token ghp_" + "A" * 36,
                 "token [REDACTED]",
             ),
-            # Bearer token
+            # Groq key
+            (
+                "key gsk_" + "a" * 30,
+                "key [REDACTED]",
+            ),
+            # Tavily key
+            (
+                "key tvly-" + "a" * 25,
+                "key [REDACTED]",
+            ),
+            # Telegram bot token
+            (
+                "bot 8511158159:AAH64DjygEnQ-ruFrsfyXeeOkvhcJAj6AKY",
+                "bot [REDACTED]",
+            ),
+            # Bearer token (long enough)
             (
                 "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig",
                 "Authorization: [REDACTED]",
+            ),
+            # Bearer short word is NOT redacted (no false positive)
+            (
+                "Use a Bearer token for auth",
+                "Use a Bearer token for auth",
             ),
             # password= query param
             (
@@ -41,6 +61,16 @@ class TestRedactSecrets:
                 "request?api_key=myrandomapikey",
                 "request?[REDACTED]",
             ),
+            # secret= query param
+            (
+                "config?secret=mysecretvalue",
+                "config?[REDACTED]",
+            ),
+            # apikey= (no underscore)
+            (
+                "url?apikey=abcdef123456",
+                "url?[REDACTED]",
+            ),
         ],
     )
     def test_pattern_redacted(self, text: str, expected: str) -> None:
@@ -55,10 +85,11 @@ class TestRedactSecrets:
 
     def test_multiple_secrets_in_one_string(self) -> None:
         text = (
-            "Using sk-" + "x" * 20 + " and token=abc123 and Bearer tok.en-val"
+            "Using sk-" + "x" * 20 + " and token=abc123"
+            " and Bearer " + "a" * 30
         )
         result = redact_secrets(text)
         assert "[REDACTED]" in result
         assert "sk-" not in result
         assert "abc123" not in result
-        assert "tok.en-val" not in result
+        assert "a" * 30 not in result

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,64 @@
+"""Tests for spare_paw.util.redact — secret redaction from log strings."""
+
+from __future__ import annotations
+
+import pytest
+
+from spare_paw.util.redact import redact_secrets
+
+
+class TestRedactSecrets:
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            # OpenRouter / OpenAI key
+            (
+                "key=sk-abcdefghijklmnopqrstuvwxyz1234",
+                "key=[REDACTED]",
+            ),
+            # GitHub token
+            (
+                "token ghp_" + "A" * 36,
+                "token [REDACTED]",
+            ),
+            # Bearer token
+            (
+                "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig",
+                "Authorization: [REDACTED]",
+            ),
+            # password= query param
+            (
+                "https://example.com?password=supersecret",
+                "https://example.com?[REDACTED]",
+            ),
+            # token= query param
+            (
+                "https://example.com?token=abc123xyz",
+                "https://example.com?[REDACTED]",
+            ),
+            # api_key= query param
+            (
+                "request?api_key=myrandomapikey",
+                "request?[REDACTED]",
+            ),
+        ],
+    )
+    def test_pattern_redacted(self, text: str, expected: str) -> None:
+        assert redact_secrets(text) == expected
+
+    def test_plain_text_unchanged(self) -> None:
+        plain = "Hello, this is a normal log message with no secrets."
+        assert redact_secrets(plain) == plain
+
+    def test_empty_string(self) -> None:
+        assert redact_secrets("") == ""
+
+    def test_multiple_secrets_in_one_string(self) -> None:
+        text = (
+            "Using sk-" + "x" * 20 + " and token=abc123 and Bearer tok.en-val"
+        )
+        result = redact_secrets(text)
+        assert "[REDACTED]" in result
+        assert "sk-" not in result
+        assert "abc123" not in result
+        assert "tok.en-val" not in result


### PR DESCRIPTION
## Summary

- Adds `util/redact.py` with regex-based redaction for OpenRouter/OpenAI keys, GitHub tokens, Bearer tokens, and query param secrets (`password=`, `token=`, `api_key=`)
- Gateway log formatter applies redaction to all log output
- Shell tool redacts command strings before logging

Closes #2

## Test plan

- [x] 9 unit tests: parametrized pattern matching, plain text passthrough, multiple secrets in one string
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)