### PR TITLE
Add per-turn tool rate limits

### DIFF
--- a/src/spare_paw/router/tool_loop.py
+++ b/src/spare_paw/router/tool_loop.py
@@ -14,6 +14,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TOOL_LIMITS: dict[str, int] = {
+    "web_scrape": 5,
+    "web_search": 5,
+    "tavily_search": 5,
+    "shell": 10,
+    "spawn_agent": 3,
+}
+
 
 async def run_tool_loop(
     client: "OpenRouterClient",
@@ -24,6 +32,7 @@ async def run_tool_loop(
     max_iterations: int = 20,
     executor: ProcessPoolExecutor | None = None,
     track_usage: bool = False,
+    tool_limits: dict[str, int] | None = None,
 ) -> str | tuple[str, dict[str, int]]:
     """Run the model in a tool-calling loop until it produces a final text response.
 
@@ -46,6 +55,9 @@ async def run_tool_loop(
         executor: Optional ProcessPoolExecutor for blocking tool functions.
         track_usage: If True, accumulate token usage across all API calls and
             return ``(response_text, usage_dict)`` instead of just the text.
+        tool_limits: Per-tool call limits for this turn. Merged on top of
+            ``DEFAULT_TOOL_LIMITS``; set a key to override a default. Tools
+            not present in the merged dict are unlimited.
 
     Returns:
         The final text content from the model when ``track_usage`` is False.
@@ -53,6 +65,12 @@ async def run_tool_loop(
         *usage_dict* has keys ``prompt_tokens``, ``completion_tokens``, and
         ``total_tokens``.
     """
+    effective_limits: dict[str, int] = {
+        **DEFAULT_TOOL_LIMITS,
+        **(tool_limits or {}),
+    }
+    call_counts: dict[str, int] = {}
+
     total_usage: dict[str, int] = {
         "prompt_tokens": 0,
         "completion_tokens": 0,
@@ -116,6 +134,30 @@ async def run_tool_loop(
             # Inject batch group_id into spawn_agent calls
             if name == "spawn_agent" and batch_group_id is not None:
                 args["group_id"] = batch_group_id
+
+            # Enforce per-turn rate limits
+            call_counts[name] = call_counts.get(name, 0) + 1
+            limit = effective_limits.get(name)
+            if limit is not None and call_counts[name] > limit:
+                result_str = (
+                    f"Rate limit: {name} called {call_counts[name]}/{limit} "
+                    "times this turn. Try a different approach."
+                )
+                logger.warning(
+                    "Iteration %d: tool %s exceeded rate limit (%d/%d)",
+                    iteration,
+                    name,
+                    call_counts[name],
+                    limit,
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call_id,
+                        "content": result_str,
+                    }
+                )
+                continue
 
             # Execute the tool, catching any exception
             try:

--- a/src/spare_paw/router/tool_loop.py
+++ b/src/spare_paw/router/tool_loop.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Per-turn (not per-session) call limits. Tools not listed are unlimited.
 DEFAULT_TOOL_LIMITS: dict[str, int] = {
     "web_scrape": 5,
     "web_search": 5,
@@ -32,7 +33,7 @@ async def run_tool_loop(
     max_iterations: int = 20,
     executor: ProcessPoolExecutor | None = None,
     track_usage: bool = False,
-    tool_limits: dict[str, int] | None = None,
+    tool_limits: dict[str, int | None] | None = None,
 ) -> str | tuple[str, dict[str, int]]:
     """Run the model in a tool-calling loop until it produces a final text response.
 
@@ -56,8 +57,8 @@ async def run_tool_loop(
         track_usage: If True, accumulate token usage across all API calls and
             return ``(response_text, usage_dict)`` instead of just the text.
         tool_limits: Per-tool call limits for this turn. Merged on top of
-            ``DEFAULT_TOOL_LIMITS``; set a key to override a default. Tools
-            not present in the merged dict are unlimited.
+            ``DEFAULT_TOOL_LIMITS``; set a value to override a default, or
+            ``None`` to remove a default limit (making the tool unlimited).
 
     Returns:
         The final text content from the model when ``track_usage`` is False.
@@ -65,9 +66,9 @@ async def run_tool_loop(
         *usage_dict* has keys ``prompt_tokens``, ``completion_tokens``, and
         ``total_tokens``.
     """
+    merged = {**DEFAULT_TOOL_LIMITS, **(tool_limits or {})}
     effective_limits: dict[str, int] = {
-        **DEFAULT_TOOL_LIMITS,
-        **(tool_limits or {}),
+        k: v for k, v in merged.items() if v is not None
     }
     call_counts: dict[str, int] = {}
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -468,3 +468,101 @@ class TestRunToolLoop:
         spawn_calls = [c for c in captured_args if c["name"] == "spawn_agent"]
         assert len(spawn_calls) == 2
         assert spawn_calls[0]["args"]["group_id"] != spawn_calls[1]["args"]["group_id"]
+
+    @pytest.mark.asyncio
+    async def test_tool_rate_limit_returns_error_instead_of_execution(self):
+        """A tool exceeding its per-turn limit gets an error result, not execution."""
+        # Model calls "web_search" twice in separate iterations; limit is 1
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(
+            side_effect=[
+                _tool_call_response("web_search", {"query": "first"}, call_id="c1"),
+                _tool_call_response("web_search", {"query": "second"}, call_id="c2"),
+                _text_response("done"),
+            ]
+        )
+
+        mock_registry = AsyncMock()
+        mock_registry.execute = AsyncMock(return_value="search result")
+
+        messages: list[dict] = [{"role": "user", "content": "search twice"}]
+        tools = [{"type": "function", "function": {"name": "web_search"}}]
+
+        result = await run_tool_loop(
+            client=mock_client,
+            messages=messages,
+            model="m",
+            tools=tools,
+            tool_registry=mock_registry,
+            tool_limits={"web_search": 1},
+        )
+
+        assert result == "done"
+        # Only the first call should have been executed
+        assert mock_registry.execute.call_count == 1
+        # The second tool result message should contain the rate limit error
+        tool_results = [m for m in messages if m.get("role") == "tool"]
+        assert len(tool_results) == 2
+        assert "Rate limit" in tool_results[1]["content"]
+        assert "web_search" in tool_results[1]["content"]
+        assert "2/1" in tool_results[1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_call_counts_reset_between_run_tool_loop_calls(self):
+        """Each invocation of run_tool_loop has independent call counts."""
+        mock_registry = AsyncMock()
+        mock_registry.execute = AsyncMock(return_value="ok")
+
+        async def _run_once() -> str:
+            client = AsyncMock()
+            client.chat = AsyncMock(
+                side_effect=[
+                    _tool_call_response("shell", {"command": "ls"}, call_id="cx"),
+                    _text_response("done"),
+                ]
+            )
+            return await run_tool_loop(
+                client=client,
+                messages=[{"role": "user", "content": "run"}],
+                model="m",
+                tools=[{"type": "function", "function": {"name": "shell"}}],
+                tool_registry=mock_registry,
+                tool_limits={"shell": 1},
+            )
+
+        # Run twice — if counts leaked, second invocation would hit the limit
+        result1 = await _run_once()
+        result2 = await _run_once()
+
+        assert result1 == "done"
+        assert result2 == "done"
+        # Both calls executed successfully (no rate-limit skip)
+        assert mock_registry.execute.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_tools_without_limits_are_unlimited(self):
+        """A tool not present in the limits dict is never rate-limited."""
+        call_count = 3
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(
+            side_effect=[
+                _tool_call_response("custom_tool", {}, call_id=f"c{i}")
+                for i in range(call_count)
+            ]
+            + [_text_response("done")]
+        )
+
+        mock_registry = AsyncMock()
+        mock_registry.execute = AsyncMock(return_value="result")
+
+        # custom_tool is absent from DEFAULT_TOOL_LIMITS, so it has no limit
+        result = await run_tool_loop(
+            client=mock_client,
+            messages=[{"role": "user", "content": "go"}],
+            model="m",
+            tools=[{"type": "function", "function": {"name": "custom_tool"}}],
+            tool_registry=mock_registry,
+        )
+
+        assert result == "done"
+        assert mock_registry.execute.call_count == call_count

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -566,3 +566,33 @@ class TestRunToolLoop:
 
         assert result == "done"
         assert mock_registry.execute.call_count == call_count
+
+    @pytest.mark.asyncio
+    async def test_none_limit_removes_default(self):
+        """Setting a tool limit to None removes the default, making it unlimited."""
+        # shell has a default limit of 10; override with None to remove it
+        call_count = 12
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(
+            side_effect=[
+                _tool_call_response("shell", {"command": "ls"}, call_id=f"c{i}")
+                for i in range(call_count)
+            ]
+            + [_text_response("done")]
+        )
+
+        mock_registry = AsyncMock()
+        mock_registry.execute = AsyncMock(return_value="ok")
+
+        result = await run_tool_loop(
+            client=mock_client,
+            messages=[{"role": "user", "content": "go"}],
+            model="m",
+            tools=[{"type": "function", "function": {"name": "shell"}}],
+            tool_registry=mock_registry,
+            tool_limits={"shell": None},
+        )
+
+        assert result == "done"
+        # All 12 calls executed — default limit of 10 was removed
+        assert mock_registry.execute.call_count == call_count


### PR DESCRIPTION
## Summary

- Adds per-turn call counters in `run_tool_loop` that enforce limits: `web_scrape` (5), `web_search` (5), `tavily_search` (5), `shell` (10), `spawn_agent` (3)
- Tools exceeding their limit get an error string returned to the model instead of execution
- Limits configurable via `tool_limits` parameter; tools not in the limits dict are unlimited
- Counter resets automatically per `run_tool_loop` invocation

Closes #18

## Test plan

- [x] 3 new tests: rate limit enforcement, counter reset between calls, unlimited tools
- [x] All 11 router tests pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)