### PR TITLE
Add retry and error handling for LCM compaction

### DIFF
--- a/src/spare_paw/bot/handler.py
+++ b/src/spare_paw/bot/handler.py
@@ -226,7 +226,7 @@ async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             "context.summary_model", "google/gemini-3.1-flash-lite-preview"
         )
         asyncio.create_task(
-            ctx_module.compact(conversation_id, app_state.router_client, summary_model),
+            ctx_module.compact_with_retry(conversation_id, app_state.router_client, summary_model),
             name="lcm-compact",
         )
 

--- a/src/spare_paw/context.py
+++ b/src/spare_paw/context.py
@@ -31,9 +31,10 @@ logger = logging.getLogger(__name__)
 # Cache the tiktoken encoder at module level
 _encoder: tiktoken.Encoding | None = None
 
-# Consecutive compaction failure counter (resets on success)
-_compact_consecutive_failures: int = 0
+# Per-conversation compaction failure counter (resets on success)
+_compact_consecutive_failures: dict[str, int] = {}
 _COMPACT_FAILURE_WARN_THRESHOLD: int = 3
+_COMPACT_RETRY_DELAY_SECONDS: float = 2
 
 
 def _get_encoder() -> tiktoken.Encoding:
@@ -319,17 +320,17 @@ async def compact_with_retry(
 ) -> None:
     """Run LCM compaction with error handling and one retry on failure.
 
-    - On first failure: logs WARNING, waits 2 seconds, retries once.
+    - On first failure: logs WARNING, waits before retrying once.
     - On retry failure: logs ERROR, skips compaction for this cycle.
-    - Tracks consecutive failures; logs a distinct WARNING at >= 3.
+    - Tracks consecutive failures per conversation; logs WARNING at >= 3.
     - Resets the failure counter on success.
-    - Source messages are never deleted on failure.
+    - Source messages are never deleted on failure. Partial summary nodes
+      may persist from a failed attempt; the next successful compaction
+      will handle remaining uncovered messages.
     """
-    global _compact_consecutive_failures
-
     try:
         await compact(conversation_id, router_client, model)
-        _compact_consecutive_failures = 0
+        _compact_consecutive_failures.pop(conversation_id, None)
         return
     except Exception as exc:
         logger.warning(
@@ -337,23 +338,24 @@ async def compact_with_retry(
             conversation_id, exc,
         )
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(_COMPACT_RETRY_DELAY_SECONDS)
 
     try:
         await compact(conversation_id, router_client, model)
-        _compact_consecutive_failures = 0
+        _compact_consecutive_failures.pop(conversation_id, None)
         return
     except Exception as exc:
-        _compact_consecutive_failures += 1
+        count = _compact_consecutive_failures.get(conversation_id, 0) + 1
+        _compact_consecutive_failures[conversation_id] = count
         logger.error(
             "LCM compaction failed (attempt 2/2) for conversation %s: %s — "
             "skipping this cycle (consecutive failures: %d)",
-            conversation_id, exc, _compact_consecutive_failures,
+            conversation_id, exc, count,
         )
-        if _compact_consecutive_failures >= _COMPACT_FAILURE_WARN_THRESHOLD:
+        if count >= _COMPACT_FAILURE_WARN_THRESHOLD:
             logger.warning(
-                "LCM compaction has failed %d+ times consecutively",
-                _COMPACT_FAILURE_WARN_THRESHOLD,
+                "LCM compaction has failed %d+ times consecutively for conversation %s",
+                _COMPACT_FAILURE_WARN_THRESHOLD, conversation_id,
             )
 
 

--- a/src/spare_paw/context.py
+++ b/src/spare_paw/context.py
@@ -14,6 +14,7 @@ Interface:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -29,6 +30,10 @@ logger = logging.getLogger(__name__)
 
 # Cache the tiktoken encoder at module level
 _encoder: tiktoken.Encoding | None = None
+
+# Consecutive compaction failure counter (resets on success)
+_compact_consecutive_failures: int = 0
+_COMPACT_FAILURE_WARN_THRESHOLD: int = 3
 
 
 def _get_encoder() -> tiktoken.Encoding:
@@ -305,6 +310,51 @@ async def compact(
 
     # 5. Condense if enough uncondensed leaves
     await _condense_summaries(conversation_id, router_client, model)
+
+
+async def compact_with_retry(
+    conversation_id: str,
+    router_client: Any,
+    model: str,
+) -> None:
+    """Run LCM compaction with error handling and one retry on failure.
+
+    - On first failure: logs WARNING, waits 2 seconds, retries once.
+    - On retry failure: logs ERROR, skips compaction for this cycle.
+    - Tracks consecutive failures; logs a distinct WARNING at >= 3.
+    - Resets the failure counter on success.
+    - Source messages are never deleted on failure.
+    """
+    global _compact_consecutive_failures
+
+    try:
+        await compact(conversation_id, router_client, model)
+        _compact_consecutive_failures = 0
+        return
+    except Exception as exc:
+        logger.warning(
+            "LCM compaction failed (attempt 1/2) for conversation %s: %s",
+            conversation_id, exc,
+        )
+
+    await asyncio.sleep(2)
+
+    try:
+        await compact(conversation_id, router_client, model)
+        _compact_consecutive_failures = 0
+        return
+    except Exception as exc:
+        _compact_consecutive_failures += 1
+        logger.error(
+            "LCM compaction failed (attempt 2/2) for conversation %s: %s — "
+            "skipping this cycle (consecutive failures: %d)",
+            conversation_id, exc, _compact_consecutive_failures,
+        )
+        if _compact_consecutive_failures >= _COMPACT_FAILURE_WARN_THRESHOLD:
+            logger.warning(
+                "LCM compaction has failed %d+ times consecutively",
+                _COMPACT_FAILURE_WARN_THRESHOLD,
+            )
 
 
 async def _create_leaf_summary(

--- a/tests/test_lcm_compaction.py
+++ b/tests/test_lcm_compaction.py
@@ -44,10 +44,10 @@ async def _init_db(tmp_path):
 
 @pytest.fixture(autouse=True)
 def _reset_failure_counter():
-    """Reset the module-level failure counter before each test."""
-    ctx_mod._compact_consecutive_failures = 0
+    """Reset the per-conversation failure counter before each test."""
+    ctx_mod._compact_consecutive_failures.clear()
     yield
-    ctx_mod._compact_consecutive_failures = 0
+    ctx_mod._compact_consecutive_failures.clear()
 
 
 def _make_mock_router_client(summary_text: str = "Summary.") -> MagicMock:
@@ -84,10 +84,10 @@ async def test_compact_retry_on_single_failure(_init_db):
     with patch("spare_paw.context.compact", side_effect=_fake_compact), \
          patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
         await compact_with_retry(conv_id, mock_client, "test-model")
-        mock_sleep.assert_awaited_once_with(2)
+        mock_sleep.assert_awaited_once()
 
     assert call_count == 2, "compact() should be called exactly twice (attempt + retry)"
-    assert ctx_mod._compact_consecutive_failures == 0
+    assert ctx_mod._compact_consecutive_failures.get(conv_id, 0) == 0
 
 
 @pytest.mark.asyncio
@@ -139,12 +139,12 @@ async def test_consecutive_failure_counter_increments(_init_db):
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await compact_with_retry(conv_id, mock_client, "test-model")
 
-    assert ctx_mod._compact_consecutive_failures == 1
+    assert ctx_mod._compact_consecutive_failures.get(conv_id, 0) == 1
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await compact_with_retry(conv_id, mock_client, "test-model")
 
-    assert ctx_mod._compact_consecutive_failures == 2
+    assert ctx_mod._compact_consecutive_failures.get(conv_id, 0) == 2
 
     config_mod.set_override("context.fresh_tail_count", 32)
 
@@ -156,7 +156,7 @@ async def test_consecutive_failure_counter_resets_on_success(_init_db):
 
     config_mod.set_override("context.fresh_tail_count", 5)
 
-    ctx_mod._compact_consecutive_failures = 2
+    ctx_mod._compact_consecutive_failures["pre-seeded"] = 2
 
     conv_id = await new_conversation()
     for i in range(15):
@@ -166,7 +166,7 @@ async def test_consecutive_failure_counter_resets_on_success(_init_db):
 
     await compact_with_retry(conv_id, mock_client, "test-model")
 
-    assert ctx_mod._compact_consecutive_failures == 0
+    assert conv_id not in ctx_mod._compact_consecutive_failures
 
     config_mod.set_override("context.fresh_tail_count", 32)
 
@@ -211,6 +211,6 @@ async def test_warning_fires_after_three_consecutive_failures(_init_db):
         "Expected a WARNING about 3+ consecutive failures, got: " + str(warning_messages)
     )
 
-    assert ctx_mod._compact_consecutive_failures == 3
+    assert ctx_mod._compact_consecutive_failures.get(conv_id, 0) == 3
 
     config_mod.set_override("context.fresh_tail_count", 32)

--- a/tests/test_lcm_compaction.py
+++ b/tests/test_lcm_compaction.py
@@ -1,0 +1,216 @@
+"""Tests for LCM compaction error handling and retry logic (Issue #3)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+import spare_paw.db as db_mod
+import spare_paw.context as ctx_mod
+from spare_paw.context import compact_with_retry, ingest, new_conversation
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def _init_db(tmp_path):
+    """Create a temp DB with all schemas applied."""
+    db_path = tmp_path / "test.db"
+
+    conn = await aiosqlite.connect(str(db_path))
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("PRAGMA journal_mode = WAL")
+    await conn.execute("PRAGMA foreign_keys = ON")
+
+    db_mod._connection = conn
+
+    await conn.executescript(db_mod.SCHEMA_V1)
+    await conn.executescript(db_mod.SCHEMA_V2)
+    await conn.executescript(db_mod.SCHEMA_V3)
+    await conn.execute(f"PRAGMA user_version = {db_mod.CURRENT_SCHEMA_VERSION}")
+    await conn.commit()
+
+    yield conn
+
+    await conn.close()
+    db_mod._connection = None
+
+
+@pytest.fixture(autouse=True)
+def _reset_failure_counter():
+    """Reset the module-level failure counter before each test."""
+    ctx_mod._compact_consecutive_failures = 0
+    yield
+    ctx_mod._compact_consecutive_failures = 0
+
+
+def _make_mock_router_client(summary_text: str = "Summary.") -> MagicMock:
+    client = MagicMock()
+    mock_response = {
+        "choices": [{"message": {"content": summary_text}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    client.chat = AsyncMock(return_value=mock_response)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compact_retry_on_single_failure(_init_db):
+    """A single compaction failure should trigger one retry and succeed."""
+    mock_client = _make_mock_router_client()
+
+    # Patch compact() itself: fail on first call, succeed on second
+    call_count = 0
+
+    async def _fake_compact(conv_id, client, model):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise Exception("transient API error")
+
+    conv_id = await new_conversation()
+
+    with patch("spare_paw.context.compact", side_effect=_fake_compact), \
+         patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        await compact_with_retry(conv_id, mock_client, "test-model")
+        mock_sleep.assert_awaited_once_with(2)
+
+    assert call_count == 2, "compact() should be called exactly twice (attempt + retry)"
+    assert ctx_mod._compact_consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_source_messages_preserved_on_failure(_init_db):
+    """Source messages must not be deleted or modified when compaction fails."""
+    from spare_paw.config import config as config_mod
+
+    config_mod.set_override("context.fresh_tail_count", 5)
+
+    conn = _init_db
+    conv_id = await new_conversation()
+    msg_ids = []
+    for i in range(15):
+        mid = await ingest(conv_id, "user", f"Important message {i}")
+        msg_ids.append(mid)
+
+    mock_client = _make_mock_router_client()
+    mock_client.chat.side_effect = Exception("permanent API failure")
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await compact_with_retry(conv_id, mock_client, "test-model")
+
+    # All original messages must still be present
+    async with conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE conversation_id = ?",
+        (conv_id,),
+    ) as cur:
+        count = (await cur.fetchone())[0]
+
+    assert count == 15, "All source messages must be preserved after compaction failure"
+
+    config_mod.set_override("context.fresh_tail_count", 32)
+
+
+@pytest.mark.asyncio
+async def test_consecutive_failure_counter_increments(_init_db):
+    """Each double-failure cycle should increment the consecutive failure counter."""
+    from spare_paw.config import config as config_mod
+
+    config_mod.set_override("context.fresh_tail_count", 5)
+
+    conv_id = await new_conversation()
+    for i in range(15):
+        await ingest(conv_id, "user", f"Message {i}")
+
+    mock_client = _make_mock_router_client()
+    mock_client.chat.side_effect = Exception("always fails")
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await compact_with_retry(conv_id, mock_client, "test-model")
+
+    assert ctx_mod._compact_consecutive_failures == 1
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await compact_with_retry(conv_id, mock_client, "test-model")
+
+    assert ctx_mod._compact_consecutive_failures == 2
+
+    config_mod.set_override("context.fresh_tail_count", 32)
+
+
+@pytest.mark.asyncio
+async def test_consecutive_failure_counter_resets_on_success(_init_db):
+    """Successful compaction must reset the consecutive failure counter to 0."""
+    from spare_paw.config import config as config_mod
+
+    config_mod.set_override("context.fresh_tail_count", 5)
+
+    ctx_mod._compact_consecutive_failures = 2
+
+    conv_id = await new_conversation()
+    for i in range(15):
+        await ingest(conv_id, "user", f"Message {i}")
+
+    mock_client = _make_mock_router_client("Good summary.")
+
+    await compact_with_retry(conv_id, mock_client, "test-model")
+
+    assert ctx_mod._compact_consecutive_failures == 0
+
+    config_mod.set_override("context.fresh_tail_count", 32)
+
+
+@pytest.mark.asyncio
+async def test_warning_fires_after_three_consecutive_failures(_init_db):
+    """A distinct WARNING should be logged after 3+ consecutive failures."""
+    import logging
+    from spare_paw.config import config as config_mod
+
+    config_mod.set_override("context.fresh_tail_count", 5)
+
+    conv_id = await new_conversation()
+    for i in range(15):
+        await ingest(conv_id, "user", f"Message {i}")
+
+    mock_client = _make_mock_router_client()
+    mock_client.chat.side_effect = Exception("always fails")
+
+    warning_messages: list[str] = []
+
+    class CapturingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            if record.levelno == logging.WARNING:
+                warning_messages.append(record.getMessage())
+
+    handler = CapturingHandler()
+    ctx_logger = logging.getLogger("spare_paw.context")
+    ctx_logger.addHandler(handler)
+
+    try:
+        for _ in range(3):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await compact_with_retry(conv_id, mock_client, "test-model")
+    finally:
+        ctx_logger.removeHandler(handler)
+
+    threshold_warnings = [
+        m for m in warning_messages if "3+ times consecutively" in m
+    ]
+    assert len(threshold_warnings) >= 1, (
+        "Expected a WARNING about 3+ consecutive failures, got: " + str(warning_messages)
+    )
+
+    assert ctx_mod._compact_consecutive_failures == 3
+
+    config_mod.set_override("context.fresh_tail_count", 32)


### PR DESCRIPTION
## Summary

- Wraps `compact()` in `compact_with_retry()` with try/except and a single retry after 2s delay
- Source messages are never lost on failure — compaction only writes new summary rows
- Tracks consecutive failures; logs WARNING at 3+ for visibility via `read_logs`
- Handler now calls `compact_with_retry()` instead of `compact()` directly

Closes #20

## Test plan

- [x] 5 new tests: retry on failure, source preservation, counter increment, counter reset on success, 3+ failure warning
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)