### PR TITLE
Mark webhook tests as slow for faster dev runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ spare-paw = "spare_paw.__main__:main"
 tui = ["rich>=13.0", "textual>=1.0"]
 dev = ["pytest", "pytest-asyncio", "rich>=13.0"]
 
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+markers = [
+    "slow: marks tests that spin up real servers or have long timeouts (deselect with '-m \"not slow\"')",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/tests/test_webhook_backend.py
+++ b/tests/test_webhook_backend.py
@@ -11,6 +11,8 @@ import pytest
 from spare_paw.backend import MessageBackend
 from spare_paw.webhook.backend import WebhookBackend, _SESSION_TTL, _current_session
 
+pytestmark = pytest.mark.slow
+
 SECRET = "test-secret"
 
 

--- a/tests/test_webhook_integration.py
+++ b/tests/test_webhook_integration.py
@@ -11,6 +11,8 @@ import pytest
 
 from spare_paw.webhook.backend import WebhookBackend, _current_session
 
+pytestmark = pytest.mark.slow
+
 SECRET = "integration-secret"
 
 # Port range: 18940–18960 (avoid collision with other test files)


### PR DESCRIPTION
## Summary
- Adds `@pytest.mark.slow` to `test_webhook_backend.py` and `test_webhook_integration.py`
- Registers the `slow` marker in `pyproject.toml`
- `pytest -m "not slow"` now runs 360 tests in **3s** vs 4m 6s for the full suite

## Usage
```bash
pytest -m "not slow"   # dev: 3s
pytest                 # pre-PR: 4min (all 400 tests)
```

## Test plan
- [x] `pytest -m "not slow"` passes (360 tests, 3s)
- [x] `pytest` passes (400 tests, 4m 6s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)