### PR TITLE
Add structured logging for auth, tokens, latency, and tool results

### DIFF
--- a/src/spare_paw/bot/commands.py
+++ b/src/spare_paw/bot/commands.py
@@ -46,7 +46,11 @@ def _get_app_state(context: ContextTypes.DEFAULT_TYPE) -> Any:
 def _is_owner(update: Update, app_state: Any) -> bool:
     """Check whether the update comes from the configured owner."""
     owner_id = app_state.config.get("telegram.owner_id")
-    return update.effective_user is not None and update.effective_user.id == owner_id
+    is_match = update.effective_user is not None and update.effective_user.id == owner_id
+    if not is_match:
+        uid = getattr(update.effective_user, "id", "unknown")
+        logger.warning("Auth rejected: telegram command from user %s", uid)
+    return is_match
 
 
 # ---------------------------------------------------------------------------

--- a/src/spare_paw/bot/handler.py
+++ b/src/spare_paw/bot/handler.py
@@ -83,9 +83,11 @@ async def _queue_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     if app_state is None:
         return
 
-    # Owner-only auth: silently ignore messages from non-owner
+    # Owner-only auth
     owner_id = app_state.config.get("telegram.owner_id")
     if update.effective_user is None or update.effective_user.id != owner_id:
+        uid = getattr(update.effective_user, "id", "unknown")
+        logger.warning("Auth rejected: telegram user %s (owner=%s)", uid, owner_id)
         return
 
     from spare_paw.backend import IncomingMessage

--- a/src/spare_paw/core/engine.py
+++ b/src/spare_paw/core/engine.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 from spare_paw import context as ctx_module
@@ -68,6 +69,7 @@ async def process_message(
     7. Background LCM compaction
     """
     ctx = ctx_module
+    t0 = time.perf_counter()
 
     # 1. Determine text content
     text = msg.text
@@ -172,6 +174,8 @@ async def process_message(
     )
 
     # 11. Send response via backend (markdown — backend handles formatting)
+    elapsed = time.perf_counter() - t0
+    logger.info("Message processed in %.1fs (%d chars response)", elapsed, len(response_text))
     await backend.send_text(response_text)
 
 

--- a/src/spare_paw/core/planner.py
+++ b/src/spare_paw/core/planner.py
@@ -61,8 +61,11 @@ async def create_plan(
             plan_messages.append(msg)
 
     try:
+        logger.info("Planning phase started (model=%s, messages=%d)", model, len(plan_messages))
         response = await client.chat(plan_messages, model)
-        return response["choices"][0]["message"].get("content", "")
+        plan_text = response["choices"][0]["message"].get("content", "")
+        logger.info("Planning phase completed (%d chars)", len(plan_text))
+        return plan_text
     except Exception:
         logger.exception("Planning phase failed — proceeding without plan")
         return ""

--- a/src/spare_paw/router/tool_loop.py
+++ b/src/spare_paw/router/tool_loop.py
@@ -109,6 +109,15 @@ async def run_tool_loop(
 
         response = await client.chat(messages, model, tools)
         _accumulate_usage(response)
+        usage = response.get("usage", {})
+        if usage:
+            logger.info(
+                "Iteration %d: tokens prompt=%d completion=%d total=%d",
+                iteration,
+                usage.get("prompt_tokens", 0),
+                usage.get("completion_tokens", 0),
+                usage.get("total_tokens", 0),
+            )
 
         if on_event is not None:
             on_event(ToolEvent(kind="llm_end", iteration=iteration))
@@ -198,8 +207,9 @@ async def run_tool_loop(
             try:
                 result = await tool_registry.execute(name, args, executor)
                 result_str = str(result) if not isinstance(result, str) else result
+                preview = result_str[:200] + "..." if len(result_str) > 200 else result_str
                 logger.info(
-                    "Iteration %d: tool %s executed successfully", iteration, name
+                    "Iteration %d: tool %s executed successfully: %s", iteration, name, preview
                 )
             except Exception as exc:
                 result_str = f"Error executing tool {name}: {exc}"

--- a/src/spare_paw/webhook/backend.py
+++ b/src/spare_paw/webhook/backend.py
@@ -51,7 +51,10 @@ class WebhookBackend:
     def _check_auth(self, request: web.Request) -> bool:
         auth = request.headers.get("Authorization", "")
         expected = f"Bearer {self._secret}"
-        return hmac.compare_digest(auth.encode(), expected.encode())
+        ok = hmac.compare_digest(auth.encode(), expected.encode())
+        if not ok:
+            logger.warning("Auth rejected: webhook %s from %s", request.path, request.remote)
+        return ok
 
     _MAX_SESSIONS = 50
 


### PR DESCRIPTION
## Summary
- Log auth failures in Telegram handler, bot commands, and webhook (all endpoints via centralized `_check_auth`)
- Log LLM token usage (prompt/completion/total) per tool loop iteration
- Log planning phase start and completion with model and plan length
- Log message processing latency (`time.perf_counter`) and response size
- Include tool result preview (first 200 chars) in execution logs

Addresses #19 (audit logging) without the schema migration — all important events are now in structured logs.

## Test plan
- [x] 360 fast tests pass
- [x] Lint clean
- [x] All log output goes through `_RedactingFormatter` so secrets in tool results are auto-redacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)