### PR TITLE
Robust agent tracking, heartbeat watchdog, and system prompt budget

### DIFF
--- a/src/spare_paw/bot/backend.py
+++ b/src/spare_paw/bot/backend.py
@@ -194,6 +194,33 @@ class TelegramBackend:
             chat_id=self._chat_id, action=ChatAction.TYPING,
         )
 
+    async def send_progress(self, text: str) -> int | None:
+        """Send an ephemeral progress message and return its message_id."""
+        try:
+            msg = await self.bot.send_message(chat_id=self._chat_id, text=text)
+            return msg.message_id
+        except Exception:
+            logger.exception("Failed to send progress message")
+            return None
+
+    async def edit_progress(self, message_id: int, text: str) -> None:
+        """Edit a previously sent progress message."""
+        try:
+            await self.bot.edit_message_text(
+                chat_id=self._chat_id, message_id=message_id, text=text,
+            )
+        except Exception:
+            logger.exception("Failed to edit progress message %d", message_id)
+
+    async def delete_progress(self, message_id: int) -> None:
+        """Delete an ephemeral progress message."""
+        try:
+            await self.bot.delete_message(
+                chat_id=self._chat_id, message_id=message_id,
+            )
+        except Exception:
+            logger.exception("Failed to delete progress message %d", message_id)
+
     async def send_notification(
         self, text: str, actions: list[dict] | None = None,
     ) -> None:
@@ -225,7 +252,7 @@ class TelegramBackend:
             BotCommand("forget", "Start a new conversation"),
             BotCommand("model", "Set model for a role (/model <role> <id>)"),
             BotCommand("models", "List available models from OpenRouter"),
-            BotCommand("roles", "List available model roles"),
+            BotCommand("roles", "List roles with assigned models"),
             BotCommand("plan", "Deep thinking: plan before executing"),
             BotCommand("mcp", "List connected MCP servers and tools"),
         ])

--- a/src/spare_paw/bot/commands.py
+++ b/src/spare_paw/bot/commands.py
@@ -358,7 +358,7 @@ async def _roles_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     if not _is_owner(update, app_state):
         return
 
-    result = await cmd_roles()
+    result = await cmd_roles(app_state)
     await update.message.reply_text(result)
 
 

--- a/src/spare_paw/bot/handler.py
+++ b/src/spare_paw/bot/handler.py
@@ -61,22 +61,6 @@ def setup_handlers(application: "Application") -> None:
 # Queue management
 # ---------------------------------------------------------------------------
 
-def start_queue_processor(application: "Application") -> None:
-    """Start the background queue processor via core/engine.
-
-    Delegates to engine.start_queue_processor which owns the queue.
-    """
-    from spare_paw.core.engine import start_queue_processor as _engine_start
-
-    app_state = application.bot_data.get("app_state")
-    backend = getattr(app_state, "backend", None) if app_state else None
-
-    if app_state and backend:
-        _engine_start(app_state, backend)
-    else:
-        logger.warning("Cannot start queue processor: app_state or backend not available")
-
-
 async def _queue_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Build IncomingMessage from Telegram Update and enqueue for processing."""
     app_state = context.bot_data.get("app_state")

--- a/src/spare_paw/context.py
+++ b/src/spare_paw/context.py
@@ -150,19 +150,32 @@ async def assemble(
     messages = [{"role": "system", "content": system_prompt}]
 
     # Inject summary nodes (compressed history) between system prompt and fresh messages
+    # Only inject the most recent summaries up to the token budget; older ones
+    # remain searchable via lcm_grep but aren't included in every request.
+    summary_budget = config.get("context.summary_token_budget", 5000)
     try:
         async with db.execute(
-            """SELECT content FROM summary_nodes
+            """SELECT content, token_count FROM summary_nodes
                WHERE conversation_id = ? AND parent_id IS NULL
-               ORDER BY created_at ASC""",
+               ORDER BY created_at DESC""",
             (conversation_id,),
         ) as cursor:
             summary_rows = await cursor.fetchall()
 
+        summary_tokens_used = 0
+        selected_summaries: list[str] = []
         for srow in summary_rows:
+            tokens = srow["token_count"]
+            if summary_tokens_used + tokens > summary_budget:
+                break
+            summary_tokens_used += tokens
+            selected_summaries.append(srow["content"])
+
+        # Reverse to chronological order (we fetched newest-first)
+        for content in reversed(selected_summaries):
             messages.append({
                 "role": "system",
-                "content": f"[Compressed History]\n{srow['content']}",
+                "content": f"[Compressed History]\n{content}",
             })
     except Exception:
         # summary_nodes table may not exist in older schemas

--- a/src/spare_paw/core/commands.py
+++ b/src/spare_paw/core/commands.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from spare_paw import context as ctx_module
-from spare_paw.config import MODEL_ROLES
+from spare_paw.config import MODEL_ROLES, resolve_model
 from spare_paw.db import DB_PATH, get_db
 
 logger = logging.getLogger(__name__)
@@ -88,9 +88,12 @@ async def cmd_search(app_state: Any, query: str) -> str:
     return text
 
 
-async def cmd_roles() -> str:
-    """List available model roles."""
-    lines = [f"  {role}" for role in MODEL_ROLES]
+async def cmd_roles(app_state: Any) -> str:
+    """List available model roles with their assigned models."""
+    lines: list[str] = []
+    for role in MODEL_ROLES:
+        model = resolve_model(app_state.config, role)
+        lines.append(f"  {role} → {model}")
     return (
         "Available roles:\n" + "\n".join(lines)
         + "\n\nUsage: /model <role> <model_id>"

--- a/src/spare_paw/core/engine.py
+++ b/src/spare_paw/core/engine.py
@@ -238,6 +238,8 @@ async def enqueue(item: IncomingMessage | tuple) -> None:
     """Put a message or agent callback on the processing queue."""
     if _message_queue is not None:
         await _message_queue.put(item)
+    else:
+        logger.error("enqueue() called but queue not initialized — item DROPPED: %s", type(item))
 
 
 def start_queue_processor(app_state: Any, backend: MessageBackend) -> None:
@@ -246,9 +248,10 @@ def start_queue_processor(app_state: Any, backend: MessageBackend) -> None:
     _message_queue = asyncio.Queue()
     _queue_task = asyncio.create_task(_process_queue(app_state, backend))
 
-    # Share the queue with the subagent module for callbacks
+    # Share the queue with the subagent module for callbacks and start watchdog
     from spare_paw.tools import subagent as subagent_mod
     subagent_mod._message_queue = _message_queue
+    subagent_mod.start_watchdog()
 
     logger.info("Message queue processor started")
 

--- a/src/spare_paw/gateway.py
+++ b/src/spare_paw/gateway.py
@@ -290,7 +290,6 @@ async def _async_main() -> None:
 
     # 10. Build backend (Telegram or webhook)
     backend_type = config.get("backend", "telegram")
-    start_queue_processor = None
 
     if backend_type == "webhook":
         from spare_paw.webhook.backend import WebhookBackend
@@ -318,12 +317,11 @@ async def _async_main() -> None:
 
         # Register Telegram handlers
         try:
-            from spare_paw.bot.handler import setup_handlers, start_queue_processor
+            from spare_paw.bot.handler import setup_handlers
 
             setup_handlers(backend._application)
             logger.info("Bot handlers registered")
         except ImportError:
-            start_queue_processor = None
             logger.warning("bot.handler not yet implemented; skipping handler registration")
 
     # 10b. Start secondary webhook backend if enabled alongside primary
@@ -376,8 +374,8 @@ async def _async_main() -> None:
         logger.info("Webhook API listening on port %d", config.get("webhook.port", 8080))
 
     # 16. Start message queue processor (must be after initialize/start)
-    if start_queue_processor is not None:
-        start_queue_processor(backend._application)
+    from spare_paw.core.engine import start_queue_processor as _start_queue
+    _start_queue(app_state, backend)
 
     logger.info("Bot started (%s backend)", backend_type)
 

--- a/src/spare_paw/router/tool_loop.py
+++ b/src/spare_paw/router/tool_loop.py
@@ -32,8 +32,8 @@ DEFAULT_TOOL_LIMITS: dict[str, int] = {
     "web_scrape": 5,
     "web_search": 5,
     "tavily_search": 5,
-    "shell": 10,
-    "spawn_agent": 3,
+    "shell": 20,
+    "spawn_agent": 5,
 }
 
 

--- a/src/spare_paw/tools/subagent.py
+++ b/src/spare_paw/tools/subagent.py
@@ -24,12 +24,22 @@ _agents: dict[str, dict[str, Any]] = {}
 _MAX_CONCURRENT = 3
 _MAX_PER_GROUP = 3  # max agents in a single group/batch
 
-# Reference to the message queue — set by handler.py at startup
+# Reference to the message queue — set by engine.py at startup
 _message_queue: asyncio.Queue | None = None
+
+# Reference to app_state — set during register()
+_app_state: Any | None = None
+
+# Watchdog settings
+_WATCHDOG_INTERVAL = 30  # seconds between scans
+_WATCHDOG_TIMEOUT = 180  # cancel after 3 minutes of inactivity
+_watchdog_task: asyncio.Task | None = None
 
 # ---------------------------------------------------------------------------
 # Agent types / archetypes
 # ---------------------------------------------------------------------------
+
+_DEFAULT_AGENT_LIMITS: dict[str, int] = {"shell": 15, "web_search": 5}
 
 AGENT_TYPES: dict[str, dict[str, Any]] = {
     "researcher": {
@@ -38,6 +48,7 @@ AGENT_TYPES: dict[str, dict[str, Any]] = {
             "and cite URLs when possible. Focus on finding accurate, up-to-date information."
         ),
         "tools": ["tavily_search", "web_scrape", "shell", "files"],
+        "tool_limits": {"web_search": 10, "tavily_search": 10, "shell": 10},
     },
     "coder": {
         "system_suffix": (
@@ -45,6 +56,7 @@ AGENT_TYPES: dict[str, dict[str, Any]] = {
             "Use the shell to run commands and verify your work."
         ),
         "tools": ["shell", "files", "code"],
+        "tool_limits": {"shell": 30, "web_search": 3},
     },
     "analyst": {
         "system_suffix": (
@@ -52,6 +64,7 @@ AGENT_TYPES: dict[str, dict[str, Any]] = {
             "and extract key insights. Be thorough but concise."
         ),
         "tools": ["files", "shell", "tavily_search"],
+        "tool_limits": {"shell": 15, "web_search": 5, "tavily_search": 5},
     },
 }
 
@@ -65,7 +78,7 @@ def _check_group_complete(group_id: str) -> bool:
     group = [a for a in _agents.values() if a.get("group_id") == group_id]
     if not group:
         return False
-    return all(a["status"] in ("completed", "failed") for a in group)
+    return all(a["status"] in ("completed", "failed", "timed_out") for a in group)
 
 
 async def _notify_main_agent(group_id: str) -> None:
@@ -93,11 +106,84 @@ async def _notify_main_agent(group_id: str) -> None:
         + "\n\n".join(parts)
     )
 
+    # Delete ephemeral progress messages
+    if _app_state is not None:
+        backend = getattr(_app_state, "backend", None)
+        if backend is not None and hasattr(type(backend), "delete_progress"):
+            for _aid2, agent in group:
+                msg_id = agent.get("progress_message_id")
+                if msg_id is not None:
+                    await backend.delete_progress(msg_id)
+
     if _message_queue is not None:
         await _message_queue.put(("agent_callback", synthetic_text))
         logger.info("Group %s: pushed callback with %d agent results", group_id, len(group))
     else:
-        logger.warning("Group %s completed but no message queue available", group_id)
+        logger.error("Group %s completed but no message queue — results DROPPED", group_id)
+
+
+def _on_agent_done(agent_id: str, task: asyncio.Task) -> None:
+    """Done-callback: detect crashes that escaped _run_agent's try/except."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is None:
+        return  # Normal completion — _run_agent already updated status
+    error_msg = f"{type(exc).__name__}: {exc}"
+    _agents[agent_id]["status"] = "failed"
+    _agents[agent_id]["error"] = error_msg
+    _agents[agent_id].setdefault(
+        "finished_at", datetime.now(timezone.utc).isoformat()
+    )
+    logger.error("Agent %s crashed (done-callback): %s", agent_id[:8], error_msg)
+
+    group_id = _agents[agent_id].get("group_id")
+    if group_id and _check_group_complete(group_id):
+        asyncio.create_task(
+            _notify_main_agent(group_id),
+            name=f"agent-notify-{group_id}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat watchdog
+# ---------------------------------------------------------------------------
+
+async def _watchdog_tick() -> None:
+    """Single pass: cancel any stuck agents."""
+    now = datetime.now(timezone.utc)
+    for agent_id, info in list(_agents.items()):
+        if info["status"] != "running":
+            continue
+        last = info.get("last_activity")
+        if last is None:
+            continue
+        elapsed = (now - last).total_seconds()
+        if elapsed > _WATCHDOG_TIMEOUT:
+            task = info.get("task")
+            if task is not None and not task.done():
+                logger.warning(
+                    "Watchdog: cancelling agent %s (no activity for %.0fs)",
+                    agent_id[:8], elapsed,
+                )
+                task.cancel()
+
+
+async def _watchdog_loop() -> None:
+    """Background loop that runs _watchdog_tick periodically."""
+    while True:
+        await asyncio.sleep(_WATCHDOG_INTERVAL)
+        try:
+            await _watchdog_tick()
+        except Exception:
+            logger.exception("Watchdog tick failed")
+
+
+def start_watchdog() -> None:
+    """Start the watchdog background task."""
+    global _watchdog_task
+    if _watchdog_task is None or _watchdog_task.done():
+        _watchdog_task = asyncio.create_task(_watchdog_loop(), name="agent-watchdog")
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +198,7 @@ async def _run_agent(
     tools_filter: list[str] | None,
     max_iterations: int,
     system_suffix: str | None = None,
+    tool_limits: dict[str, int] | None = None,
 ) -> None:
     """Background task that runs a self-contained tool loop and notifies on completion."""
     _agents[agent_id]["status"] = "running"
@@ -156,6 +243,10 @@ async def _run_agent(
             {"role": "user", "content": prompt},
         ]
 
+        # Heartbeat callback — updates last_activity on every tool event
+        def _heartbeat(event: Any) -> None:
+            _agents[agent_id]["last_activity"] = datetime.now(timezone.utc)
+
         # Run tool loop with usage tracking
         result_text, usage = await run_tool_loop(
             client=app_state.router_client,
@@ -166,6 +257,8 @@ async def _run_agent(
             max_iterations=max_iterations,
             executor=app_state.executor,
             track_usage=True,
+            tool_limits=tool_limits,
+            on_event=_heartbeat,
         )
 
         _agents[agent_id]["status"] = "completed"
@@ -173,6 +266,11 @@ async def _run_agent(
         _agents[agent_id]["result_preview"] = result_text[:200]
         _agents[agent_id]["usage"] = usage
         logger.info("Agent %s completed", agent_id[:8])
+
+    except asyncio.CancelledError:
+        _agents[agent_id]["status"] = "timed_out"
+        _agents[agent_id]["error"] = "Agent timed out: no activity for too long"
+        logger.warning("Agent %s timed out (cancelled by watchdog)", agent_id[:8])
 
     except Exception as exc:
         error_msg = f"{type(exc).__name__}: {exc}"
@@ -182,6 +280,25 @@ async def _run_agent(
 
     finally:
         _agents[agent_id]["finished_at"] = datetime.now(timezone.utc).isoformat()
+
+        # Edit progress message with per-agent status
+        progress_msg_id = _agents[agent_id].get("progress_message_id")
+        if progress_msg_id is not None:
+            backend = getattr(app_state, "backend", None)
+            if backend is not None and hasattr(type(backend), "edit_progress"):
+                group_id = _agents[agent_id].get("group_id")
+                if group_id:
+                    group = [a for a in _agents.values() if a.get("group_id") == group_id]
+                    done = sum(1 for a in group if a["status"] in ("completed", "failed", "timed_out"))
+                    total = len(group)
+                    status_emoji = "\u2705" if _agents[agent_id]["status"] == "completed" else "\u274c"
+                    try:
+                        await backend.edit_progress(
+                            progress_msg_id,
+                            f"{status_emoji} {_agents[agent_id].get('name', 'agent')} done ({done}/{total})",
+                        )
+                    except Exception:
+                        pass
 
         # Check if the group is complete and notify
         group_id = _agents[agent_id].get("group_id")
@@ -223,11 +340,13 @@ async def _handle_spawn(
     # Resolve agent type
     tools_filter = tools
     system_suffix: str | None = None
+    agent_tool_limits: dict[str, int] | None = _DEFAULT_AGENT_LIMITS
     if agent_type and agent_type in AGENT_TYPES:
         archetype = AGENT_TYPES[agent_type]
         if tools_filter is None:
             tools_filter = archetype["tools"]
         system_suffix = archetype["system_suffix"]
+        agent_tool_limits = archetype.get("tool_limits", _DEFAULT_AGENT_LIMITS)
 
     # Assign group_id (create new one if not provided)
     resolved_group_id = group_id or str(uuid.uuid4())[:8]
@@ -240,16 +359,26 @@ async def _handle_spawn(
         "group_id": resolved_group_id,
         "agent_type": agent_type,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        "last_activity": datetime.now(timezone.utc),
     }
 
-    # Launch as background task
-    asyncio.create_task(
+    # Launch as background task with done-callback for crash detection
+    task = asyncio.create_task(
         _run_agent(
             agent_id, prompt, app_state, model, tools_filter,
             max_iterations, system_suffix,
+            tool_limits=agent_tool_limits,
         ),
         name=f"agent-{agent_id}",
     )
+    _agents[agent_id]["task"] = task
+    task.add_done_callback(lambda t, aid=agent_id: _on_agent_done(aid, t))
+
+    # Send ephemeral progress message (Telegram-specific)
+    backend = getattr(app_state, "backend", None)
+    if backend is not None and hasattr(type(backend), "send_progress"):
+        msg_id = await backend.send_progress(f"\u23f3 Working on: {name}...")
+        _agents[agent_id]["progress_message_id"] = msg_id
 
     logger.info("Spawned agent %s: %s (group=%s)", agent_id, name, resolved_group_id)
     return json.dumps({
@@ -264,15 +393,24 @@ async def _handle_list_agents() -> str:
     """List all agents and their status."""
     agents = []
     for aid, info in _agents.items():
+        task = info.get("task")
         entry: dict[str, Any] = {
             "id": aid,
             "name": info.get("name"),
             "status": info.get("status"),
+            "agent_type": info.get("agent_type"),
+            "group_id": info.get("group_id"),
             "created_at": info.get("created_at"),
             "finished_at": info.get("finished_at"),
         }
+        if info.get("error"):
+            entry["error"] = info["error"]
+        if info.get("result_preview"):
+            entry["result_preview"] = info["result_preview"]
         if "usage" in info:
             entry["usage"] = info["usage"]
+        if task is not None:
+            entry["is_alive"] = not task.done()
         agents.append(entry)
     # Most recent first
     agents.sort(key=lambda a: a.get("created_at", ""), reverse=True)
@@ -327,6 +465,8 @@ LIST_AGENTS_SCHEMA: dict[str, Any] = {
 
 def register(registry: Any, config: dict[str, Any], app_state: Any) -> None:
     """Register spawn_agent and list_agents tools."""
+    global _app_state
+    _app_state = app_state
 
     async def _spawn_handler(
         name: str,

--- a/src/spare_paw/tui/app.py
+++ b/src/spare_paw/tui/app.py
@@ -437,7 +437,7 @@ if HAS_TEXTUAL:
 
             if text.lower() == "/roles":
                 from spare_paw.core.commands import cmd_roles
-                result = await cmd_roles()
+                result = await cmd_roles(self.app_state)
                 log_widget.write(result)
                 return
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -130,15 +130,29 @@ class TestCmdModel:
 
 class TestCmdRoles:
     @pytest.mark.asyncio
-    async def test_lists_all_roles(self):
+    async def test_lists_all_roles_with_models(self):
         from spare_paw.core.commands import cmd_roles
 
-        result = await cmd_roles()
+        app_state = MagicMock()
+        app_state.config.get.side_effect = lambda key, default="": {
+            "models.main_agent": "google/gemini-3.1-flash-lite-preview",
+            "models.coder": "z-ai/glm-5",
+            "models.planner": "",
+            "models.cron": "",
+            "models.researcher": "",
+            "models.analyst": "",
+            "models.summary": "",
+        }.get(key, default)
+
+        result = await cmd_roles(app_state)
 
         assert "main_agent" in result
         assert "coder" in result
         assert "researcher" in result
         assert "summary" in result
+        assert "google/gemini-3.1-flash-lite-preview" in result
+        assert "z-ai/glm-5" in result
+        assert "→" in result
         assert "/model" in result
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -112,6 +112,47 @@ async def test_assemble_respects_token_budget(_init_db, monkeypatch):
     config_mod.config.set_override("context.safety_margin", 0.85)
 
 
+@pytest.mark.asyncio
+async def test_assemble_caps_summary_tokens(_init_db, monkeypatch):
+    """Summaries exceeding the budget are dropped (oldest first)."""
+    from spare_paw import config as config_mod
+    from spare_paw.context import count_tokens
+
+    conv_id = await new_conversation()
+    await ingest(conv_id, "user", "Hello")
+
+    db = _init_db
+    # Ensure summary_nodes table exists (it's in SCHEMA_V3)
+    await db.executescript(db_mod.SCHEMA_V3)
+    await db.commit()
+    # Insert 10 summary nodes, each ~500 tokens worth of text
+    for i in range(10):
+        content = f"Summary {i}: " + ("word " * 500)  # ~500 tokens each
+        await db.execute(
+            """INSERT INTO summary_nodes
+               (id, conversation_id, parent_id, depth, content, token_count, source_msg_ids, created_at)
+               VALUES (?, ?, NULL, 0, ?, ?, '[]', datetime('now', ?))""",
+            (f"node-{i}", conv_id, content, count_tokens(content), f"+{i} minutes"),
+        )
+    await db.commit()
+
+    # Set summary budget to 2000 tokens — should fit ~4 of 10 summaries
+    config_mod.config.set_override("context.summary_token_budget", 2000)
+
+    messages = await assemble(conv_id, "sys")
+
+    # Count compressed history messages
+    summaries = [m for m in messages if "[Compressed History]" in m.get("content", "")]
+    assert len(summaries) < 10, f"Expected fewer than 10 summaries, got {len(summaries)}"
+    assert len(summaries) > 0, "Expected at least some summaries"
+
+    # The surviving summaries should be the NEWEST ones
+    last_summary = summaries[-1]["content"]
+    assert "Summary 9" in last_summary, "Newest summary should be included"
+
+    config_mod.config.set_override("context.summary_token_budget", 5000)
+
+
 # ---------------------------------------------------------------------------
 # search (FTS5)
 # ---------------------------------------------------------------------------

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -362,6 +362,19 @@ class TestEnqueue:
         engine_mod._message_queue = None
         await enqueue(IncomingMessage(text="ignored"))  # should not raise
 
+    @pytest.mark.asyncio
+    async def test_enqueue_logs_error_when_no_queue(self, caplog):
+        """enqueue logs ERROR when queue is None."""
+        import logging
+        import spare_paw.core.engine as engine_mod
+
+        engine_mod._message_queue = None
+        with caplog.at_level(logging.ERROR, logger="spare_paw.core.engine"):
+            await enqueue(IncomingMessage(text="dropped"))
+        assert any("DROPPED" in r.message for r in caplog.records), (
+            "Expected ERROR log with 'DROPPED' when queue is None"
+        )
+
 
 class TestStartQueueProcessor:
     @pytest.mark.asyncio

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -443,6 +444,360 @@ def test_agents_cannot_use_send_message_or_send_file():
 
     tool_names = {t["function"]["name"] for t in filtered}
     assert tool_names == {"shell", "files"}
+
+
+# ---------------------------------------------------------------------------
+# Per-agent-type tool limits
+# ---------------------------------------------------------------------------
+
+def test_agent_types_have_tool_limits():
+    """Each AGENT_TYPES entry must have a tool_limits dict."""
+    for key, archetype in subagent_mod.AGENT_TYPES.items():
+        assert "tool_limits" in archetype, f"AGENT_TYPES['{key}'] missing 'tool_limits'"
+        assert isinstance(archetype["tool_limits"], dict)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_forwards_tool_limits_to_tool_loop():
+    """_run_agent passes tool_limits to run_tool_loop."""
+    app_state = _make_app_state()
+    agent_id = "limits-test"
+    subagent_mod._agents[agent_id] = {
+        "name": "limiter",
+        "prompt": "test",
+        "status": "starting",
+        "group_id": "grp",
+        "agent_type": "coder",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    expected_limits = {"shell": 30, "web_search": 3}
+
+    with patch("spare_paw.router.tool_loop.run_tool_loop", return_value=("ok", {})) as mock_loop:
+        with patch("spare_paw.bot.handler._build_system_prompt", return_value="sys"):
+            await subagent_mod._run_agent(
+                agent_id, "test", app_state,
+                model=None, tools_filter=None, max_iterations=5,
+                tool_limits=expected_limits,
+            )
+
+    assert mock_loop.call_args.kwargs.get("tool_limits") == expected_limits
+
+
+@pytest.mark.asyncio
+async def test_default_agent_limits_when_no_type():
+    """Spawn without agent_type uses _DEFAULT_AGENT_LIMITS."""
+    app_state = _make_app_state()
+
+    with patch.object(subagent_mod, "_run_agent", side_effect=_noop_run_agent) as mock_run:
+        await subagent_mod._handle_spawn(app_state, name="generic", prompt="do stuff")
+
+    call_args = mock_run.call_args
+    tool_limits = call_args[1].get("tool_limits") if call_args[1] else None
+    assert tool_limits == subagent_mod._DEFAULT_AGENT_LIMITS
+    await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat watchdog
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_agent_has_last_activity():
+    """Spawned agent has a last_activity datetime field."""
+    app_state = _make_app_state()
+
+    with patch.object(subagent_mod, "_run_agent", side_effect=_noop_run_agent):
+        await subagent_mod._handle_spawn(app_state, name="hb", prompt="test")
+
+    agent_id = next(iter(subagent_mod._agents))
+    assert "last_activity" in subagent_mod._agents[agent_id]
+    assert isinstance(subagent_mod._agents[agent_id]["last_activity"], datetime)
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_watchdog_cancels_stuck_agent():
+    """Watchdog cancels agents with no recent activity."""
+    mock_task = MagicMock()
+    mock_task.done.return_value = False
+
+    subagent_mod._agents["stuck-1"] = {
+        "name": "stuck",
+        "status": "running",
+        "last_activity": datetime.now(timezone.utc) - timedelta(seconds=300),
+        "task": mock_task,
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    await subagent_mod._watchdog_tick()
+    mock_task.cancel.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_watchdog_ignores_active_agent():
+    """Watchdog does not cancel agents with recent activity."""
+    mock_task = MagicMock()
+    mock_task.done.return_value = False
+
+    subagent_mod._agents["active-1"] = {
+        "name": "active",
+        "status": "running",
+        "last_activity": datetime.now(timezone.utc) - timedelta(seconds=10),
+        "task": mock_task,
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    await subagent_mod._watchdog_tick()
+    mock_task.cancel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_watchdog_ignores_completed_agent():
+    """Watchdog does not cancel completed agents even with old last_activity."""
+    mock_task = MagicMock()
+    mock_task.done.return_value = True
+
+    subagent_mod._agents["done-1"] = {
+        "name": "done",
+        "status": "completed",
+        "last_activity": datetime.now(timezone.utc) - timedelta(seconds=300),
+        "task": mock_task,
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    await subagent_mod._watchdog_tick()
+    mock_task.cancel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_agent_sets_timed_out():
+    """CancelledError in _run_agent sets status to timed_out."""
+    app_state = _make_app_state()
+    agent_id = "timeout-test"
+    subagent_mod._agents[agent_id] = {
+        "name": "timeouter",
+        "prompt": "test",
+        "status": "starting",
+        "group_id": "grp",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    async def _raise_cancelled(*args, **kwargs):
+        raise asyncio.CancelledError()
+
+    with patch("spare_paw.router.tool_loop.run_tool_loop", side_effect=_raise_cancelled):
+        with patch("spare_paw.bot.handler._build_system_prompt", return_value="sys"):
+            await subagent_mod._run_agent(
+                agent_id, "test", app_state,
+                model=None, tools_filter=None, max_iterations=5,
+            )
+
+    assert subagent_mod._agents[agent_id]["status"] == "timed_out"
+    assert "timed out" in subagent_mod._agents[agent_id]["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral progress messages
+# ---------------------------------------------------------------------------
+
+class _ProgressBackend:
+    """Fake backend class with progress methods for testing."""
+    send_progress = AsyncMock(return_value=42)
+    edit_progress = AsyncMock()
+    delete_progress = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_spawn_sends_progress_message():
+    """Spawn sends a progress message via backend.send_progress."""
+    app_state = _make_app_state()
+    backend = _ProgressBackend()
+    backend.send_progress = AsyncMock(return_value=42)
+    app_state.backend = backend
+
+    with patch.object(subagent_mod, "_run_agent", side_effect=_noop_run_agent):
+        await subagent_mod._handle_spawn(app_state, name="prog", prompt="test")
+
+    backend.send_progress.assert_called_once()
+    agent_id = next(iter(subagent_mod._agents))
+    assert subagent_mod._agents[agent_id]["progress_message_id"] == 42
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_group_complete_deletes_progress():
+    """_notify_main_agent deletes progress messages for the group."""
+    group_id = "prog-group"
+    backend = _ProgressBackend()
+    backend.delete_progress = AsyncMock()
+
+    mock_app_state = MagicMock()
+    mock_app_state.backend = backend
+    subagent_mod._app_state = mock_app_state
+
+    subagent_mod._agents["pg-1"] = {
+        "name": "agent1",
+        "status": "completed",
+        "result": "result1",
+        "group_id": group_id,
+        "progress_message_id": 101,
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    queue = asyncio.Queue()
+    original_queue = subagent_mod._message_queue
+    subagent_mod._message_queue = queue
+    try:
+        await subagent_mod._notify_main_agent(group_id)
+        backend.delete_progress.assert_called_once_with(101)
+    finally:
+        subagent_mod._message_queue = original_queue
+        subagent_mod._app_state = None
+
+
+@pytest.mark.asyncio
+async def test_no_progress_without_backend_support():
+    """Spawn succeeds even if backend lacks send_progress."""
+    app_state = _make_app_state()
+    app_state.backend = MagicMock(spec=[])  # No send_progress attribute
+
+    with patch.object(subagent_mod, "_run_agent", side_effect=_noop_run_agent):
+        result = json.loads(
+            await subagent_mod._handle_spawn(app_state, name="noprog", prompt="test")
+        )
+
+    assert result["__stop_turn__"] is True
+    agent_id = next(iter(subagent_mod._agents))
+    assert subagent_mod._agents[agent_id].get("progress_message_id") is None
+    await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# Integration: full dispatch path (tool_loop → registry → _spawn_handler)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Robust agent tracking (done-callback, enriched list, null-queue escalation)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_spawn_stores_task_reference():
+    """Spawned agents must have an asyncio.Task stored in _agents."""
+    app_state = _make_app_state()
+
+    with patch.object(subagent_mod, "_run_agent", side_effect=_noop_run_agent):
+        await subagent_mod._handle_spawn(app_state, name="tracked", prompt="test")
+
+    agent_id = next(iter(subagent_mod._agents))
+    agent = subagent_mod._agents[agent_id]
+    assert "task" in agent, "Agent entry must contain a 'task' key"
+    assert isinstance(agent["task"], asyncio.Task)
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_done_callback_detects_crash():
+    """If an agent task raises outside _run_agent's try/except, done-callback catches it."""
+    agent_id = "crash-test"
+    group_id = "crash-group"
+
+    async def _crashing_agent(*args, **kwargs):
+        raise RuntimeError("unexpected crash")
+
+    subagent_mod._agents[agent_id] = {
+        "name": "crasher",
+        "prompt": "test",
+        "status": "starting",
+        "group_id": group_id,
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    task = asyncio.create_task(_crashing_agent(), name=f"agent-{agent_id}")
+    subagent_mod._agents[agent_id]["task"] = task
+    task.add_done_callback(lambda t, aid=agent_id: subagent_mod._on_agent_done(aid, t))
+
+    # Wait for task to complete and callback to fire
+    try:
+        await task
+    except RuntimeError:
+        pass
+    await asyncio.sleep(0)
+
+    agent = subagent_mod._agents[agent_id]
+    assert agent["status"] == "failed"
+    assert "RuntimeError" in agent["error"]
+    assert "finished_at" in agent
+
+
+@pytest.mark.asyncio
+async def test_null_queue_logs_error(caplog):
+    """_notify_main_agent logs ERROR (not WARNING) when queue is None."""
+    group_id = "null-queue-group"
+    subagent_mod._agents["nq-1"] = {
+        "name": "agent1",
+        "status": "completed",
+        "result": "some result",
+        "group_id": group_id,
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    original_queue = subagent_mod._message_queue
+    subagent_mod._message_queue = None
+    try:
+        import logging
+        with caplog.at_level(logging.ERROR, logger="spare_paw.tools.subagent"):
+            await subagent_mod._notify_main_agent(group_id)
+        assert any("DROPPED" in r.message for r in caplog.records), (
+            "Expected ERROR log with 'DROPPED' when queue is None"
+        )
+    finally:
+        subagent_mod._message_queue = original_queue
+
+
+@pytest.mark.asyncio
+async def test_list_agents_includes_enriched_fields():
+    """list_agents output includes error, result_preview, agent_type, group_id, is_alive."""
+    mock_task = MagicMock()
+    mock_task.done.return_value = True
+
+    subagent_mod._agents["e1"] = {
+        "name": "failed-agent",
+        "status": "failed",
+        "error": "RuntimeError: boom",
+        "result_preview": None,
+        "agent_type": "researcher",
+        "group_id": "grp-1",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "finished_at": "2026-01-01T00:01:00+00:00",
+        "task": mock_task,
+    }
+    subagent_mod._agents["e2"] = {
+        "name": "ok-agent",
+        "status": "completed",
+        "result": "full result text here",
+        "result_preview": "full result text here",
+        "agent_type": "coder",
+        "group_id": "grp-1",
+        "created_at": "2026-01-01T00:02:00+00:00",
+        "finished_at": "2026-01-01T00:03:00+00:00",
+        "task": mock_task,
+    }
+
+    result = json.loads(await subagent_mod._handle_list_agents())
+    assert result["count"] == 2
+
+    # Check enriched fields on the failed agent (second in list, sorted by created_at desc)
+    failed = next(a for a in result["agents"] if a["name"] == "failed-agent")
+    assert failed["error"] == "RuntimeError: boom"
+    assert failed["agent_type"] == "researcher"
+    assert failed["group_id"] == "grp-1"
+    assert "is_alive" in failed
+    assert failed["is_alive"] is False
+
+    ok = next(a for a in result["agents"] if a["name"] == "ok-agent")
+    assert ok["result_preview"] == "full result text here"
+    assert ok["agent_type"] == "coder"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_event.py
+++ b/tests/test_tool_event.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from spare_paw.router.tool_loop import ToolEvent, run_tool_loop
+from spare_paw.router.tool_loop import DEFAULT_TOOL_LIMITS, ToolEvent, run_tool_loop
 
 
 def _text_response(content: str = "done") -> dict:
@@ -159,3 +159,16 @@ class TestOnTokenCallback:
             on_token=None,
         )
         assert result == "hi"
+
+
+class TestDefaultToolLimits:
+    def test_shell_limit(self):
+        assert DEFAULT_TOOL_LIMITS["shell"] == 20
+
+    def test_spawn_agent_limit(self):
+        assert DEFAULT_TOOL_LIMITS["spawn_agent"] == 5
+
+    def test_web_limits_unchanged(self):
+        assert DEFAULT_TOOL_LIMITS["web_scrape"] == 5
+        assert DEFAULT_TOOL_LIMITS["web_search"] == 5
+        assert DEFAULT_TOOL_LIMITS["tavily_search"] == 5


### PR DESCRIPTION
## Summary
- **Agent reliability**: Fix queue init race, store Task refs with done-callbacks, escalate null-queue drops to ERROR, enrich `list_agents` output
- **Per-agent-type tool limits**: Agents get independent rate limits based on type (researcher: web_search=10, coder: shell=30, etc.)
- **Heartbeat watchdog**: Tracks `last_activity` per agent, cancels stuck agents after 3min of inactivity
- **Ephemeral progress messages**: Send → edit → delete Telegram messages during agent execution
- **Summary token budget**: Cap compressed history in system prompt to 5K tokens; old summaries remain searchable via `lcm_grep`
- **`/roles` shows model assignments**: Each role displays its resolved model
- **Raised tool limits**: shell=20, spawn_agent=5

Fixes #34, fixes #35, closes #36, closes #37, closes #38

## Test plan
- [x] 33 subagent tests pass (including 13 new tests for all features)
- [x] Context test for summary budget cap
- [x] Engine test for null-queue error logging
- [x] Full test suite passes (100%)
- [x] Ruff linter clean
- [x] Deployed to phone, verified agent spawn → progress → delete → result flow in Telegram logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)