### PR TITLE
Robustness audit fixes: restart-safe agents, honest failures, real concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,12 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # The slow-marked webhook integration tests alone take ~4 minutes.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: pip install -e ".[dev]" pytest-timeout
-      - run: pytest tests/ -v --timeout=30
+      - run: pip install -e ".[dev]"
+      - run: pytest tests/ -v --timeout=120

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ feat/
 *.log
 logs/
 IDENTITY_vareesha.md
+.claude/

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A 24/7 personal AI agent accessible through Telegram. Runs on macOS, Linux, Wind
 
 - **Role-based model selection** -- 8 model roles (main_agent, coder, planner, cron, researcher, analyst, summary, vision) each independently configurable via OpenRouter; fallback chain: role-specific model -> main_agent -> google/gemini-2.0-flash
 - **Tool use** -- shell commands, file operations, web search, web scraping, browser automation, cron management; all exposed as LLM function calls
-- **Scheduled tasks (cron)** -- create, edit, pause, resume, and manage recurring AI tasks with per-cron model selection
+- **Scheduled tasks (cron)** -- create, edit, pause, resume, and manage recurring AI tasks with per-cron model selection; jobs missed while the bot is down run once on restart, one-shot reminders can never double-fire, and schedules can be pinned to an explicit timezone via `cron.timezone`
 - **One-shot reminders** -- ask the bot to remind you of something in X minutes/hours; it creates a cron that fires once and auto-deletes itself (e.g. "remind me to call John in 30 minutes")
 - **Photo/image and video support** -- send photos and videos via Telegram; images and videos are preprocessed through a vision-capable model (configurable via `models.vision`, defaults to `google/gemini-3.1-flash-lite-preview`) to generate text descriptions. The main agent receives text summaries instead of raw media, reducing token costs while preserving semantic content. Captions are used as the prompt (defaults to "What do you see in this image/video?")
-- **Voice messages** -- Groq Whisper transcription for Telegram voice notes
+- **Voice messages** -- Groq Whisper transcription for Telegram voice notes; if transcription fails you get a reply saying so instead of silence
 - **Prompt files** -- loads `IDENTITY.md`, `USER.md`, and `SYSTEM.md` from `~/.spare-paw/` on every turn for personality, user preferences, and device context. Editable live without restart
 - **Full-text search** -- FTS5-backed search across all conversation history
 - **DAG-based lossless context management (LCM)** -- when conversation history grows beyond the fresh tail (32 messages), older messages are automatically summarized into leaf nodes (~8 messages each); when 4+ leaves accumulate they condense into higher-level summaries. Every original message is preserved and searchable. Summaries are assembled between the system prompt and fresh messages so the LLM retains awareness of older context. Compaction uses a cheap configurable model (default `google/gemini-3.1-flash-lite`) to keep costs low
@@ -19,7 +19,9 @@ A 24/7 personal AI agent accessible through Telegram. Runs on macOS, Linux, Wind
 - **Message queue with backpressure** -- incoming messages queue while the bot is busy; typing indicator signals processing
 - **Heartbeat watchdog** -- detects event loop starvation and deadlocks, not just process crashes
 - **Deep thinking (`/plan`)** -- on-demand planning phase that decomposes complex requests into a structured execution plan before the tool loop runs. A single cheap LLM call (no tools) produces a step-by-step plan with tool/agent classification and parallelism hints; the plan is injected as context for the main model to follow. Regular messages skip planning entirely (zero overhead)
-- **Agent orchestration** -- spawn multiple subagents in a single turn; agents spawned in the same tool-call batch are deterministically grouped (via a shared batch group_id injected by the tool loop) and their results are delivered together as one synthesized response. Three predefined archetypes: `researcher` (web search + scraping), `coder` (shell + files), `analyst` (data analysis), each with preset tools and system prompt. Safety limits: max 3 concurrent agents, max 3 per group
+- **Agent orchestration** -- spawn multiple subagents in a single turn; agents spawned in the same tool-call batch are deterministically grouped (via a shared batch group_id injected by the tool loop) and their results are delivered together as one synthesized response. Agents run genuinely in parallel: LLM concurrency is configurable via `llm.max_concurrent` (default 4). Four predefined archetypes: `researcher` (web search + scraping + browser), `coder` (shell + files), `analyst` (data analysis), `browser` (web automation), each with preset tools and system prompt; `researcher` and `browser` run without shell or file access since they consume untrusted web content. Safety limits: max 3 concurrent agents, max 3 per group, plus a per-agent token budget and iteration cap (`agent.subagent_token_budget`, `agent.subagent_max_iterations_cap`)
+- **Restart-safe agents** -- agent state and results are persisted to SQLite; after a restart the bot tells you which agents were interrupted and delivers any results that hadn't been sent yet
+- **Honest failure reporting** -- LLM timeouts, token-budget stops, and iteration limits are reported to you as failures instead of being silently recorded or disguised as replies; a per-message processing timeout (`agent.message_timeout_seconds`, default 600s) notifies you rather than hanging forever
 - **Bidirectional agent dialogue** -- subagents can consult the main agent for clarification or decision-making via the `consult_main` tool. Supports up to 5 rounds of back-and-forth within a single spawn, enabling complex collaborative workflows where agents ask questions before proceeding with their work
 - **Token/cost tracking** -- per-agent token usage tracking (prompt, completion, total) from OpenRouter, visible via `list_agents`
 - **MCP client** -- connect to external MCP servers (GitHub, filesystem, etc.) and use their tools alongside native tools
@@ -124,7 +126,9 @@ A template is provided at `config.example.yaml`. Key sections:
 | `context` | `max_messages`, `token_budget`, `safety_margin`, `fresh_tail_count`, `leaf_chunk_size`, `condensed_min_fanout` |
 | `tools` | Per-tool enable/disable, timeouts, allowed paths |
 | `mcp` | MCP client server connections |
-| `agent` | `max_tool_iterations`, `system_prompt` template |
+| `llm` | `max_concurrent` — parallel LLM calls across main agent + subagents (default 4) |
+| `agent` | `max_tool_iterations`, `subagent_token_budget` (default 150000), `subagent_max_iterations_cap` (default 30), `message_timeout_seconds` (default 600), `system_prompt` template |
+| `cron` | `timezone` — explicit timezone for cron schedules (defaults to system local) |
 | `logging` | Log level, rotation size, backup count |
 
 Role-based model configuration:
@@ -401,6 +405,7 @@ MCP support requires `mcp>=1.26.0`, included in the package dependencies.
 - **Lazy launch** -- Chromium is started on the first `browser_*` call and reuses the same instance across tool calls within a conversation
 - **Navigate, interact, extract** -- `browser_navigate`, `browser_click`, `browser_type`, `browser_get_text`, `browser_get_elements`, `browser_eval_js`
 - **Visual feedback** -- `browser_screenshot` returns a page screenshot; `browser_wait` blocks until a selector appears
+- **Private screenshots** -- screenshots are stored in `~/.spare-paw/screenshots` (owner-only permissions) and auto-deleted after 7 days
 - **Requirement** -- `chromium-browser` (or equivalent) must be installed on the system (`pkg install chromium` on Termux, `brew install --cask chromium` on macOS)
 
 ## GitHub Integration
@@ -499,7 +504,7 @@ Core Engine (core/engine.py)
 Context Manager (SQLite + FTS5 + DAG-based lossless context management)
   |
   v
-Model Router (OpenRouter API, role-based selection, semaphore-serialized, retry with backoff)
+Model Router (OpenRouter API, role-based selection, bounded concurrency, retry with backoff)
   |
   v
 Tools (ProcessPoolExecutor: shell, files, web search, web scrape, browser, cron, vision)
@@ -516,13 +521,15 @@ The core engine is decoupled from any specific frontend via the `MessageBackend`
 Key design points:
 
 - Single async event loop with a ProcessPoolExecutor (4 workers) for blocking operations
-- `asyncio.Semaphore(1)` serializes all model API calls to prevent races
+- Model API calls run under a bounded semaphore (`llm.max_concurrent`, default 4), so parallel agents make genuinely parallel LLM calls
 - Heartbeat file touched every 30s; watchdog restarts if stale beyond 90s
 - Cron outputs are delivered to the active backend but do not enter conversation memory
 - Subagents don't message the user directly; results flow back through a group callback queue, letting the main LLM synthesize a unified response. Results are stored in conversation memory for follow-up questions
+- Agent state and results are persisted to SQLite (schema v4); on startup, agents orphaned by a restart are marked interrupted and reported to the user, and any undelivered results are re-enqueued
+- Telegram sends retry with exponential backoff on transient network errors before giving up
 - Multiple agents spawned in one tool-call batch are deterministically grouped by the tool loop (shared batch group_id); the turn stop is deferred until all spawns in the batch complete
 - Safety limits: max 3 concurrent agents, max 3 per group
-- Three agent archetypes (`researcher`, `coder`, `analyst`) each set appropriate tools and system prompt
+- Four agent archetypes (`researcher`, `coder`, `analyst`, `browser`) each set appropriate tools and system prompt; `researcher` and `browser` get no shell/file access (least privilege against prompt injection from web content)
 - Each agent tracks token usage (prompt, completion, total) from OpenRouter API responses
 - Token counting uses tiktoken with a configurable safety margin for non-OpenAI models
 - DAG compaction runs automatically after each turn: messages beyond the fresh tail are chunked into leaf summaries, and when enough leaves accumulate they condense into higher-level nodes. Schema v3 adds a `summary_nodes` table with FTS5 index. `assemble()` injects compressed history between the system prompt and fresh messages

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -59,8 +59,18 @@ tools:
   cron:
     enabled: true
 
+# Cron scheduling
+# cron:
+#   timezone: "Asia/Kolkata"  # explicit timezone for cron schedules; defaults to system local
+
+llm:
+  max_concurrent: 4  # parallel LLM calls (main agent + subagents + consults)
+
 agent:
   max_tool_iterations: 20
+  subagent_max_iterations_cap: 30  # hard server-side iteration cap for spawned subagents
+  subagent_token_budget: 150000    # per-subagent token budget; the agent is stopped when exhausted
+  message_timeout_seconds: 600     # wall-clock ceiling for processing one message end-to-end
   # The system_prompt uses {current_time} as a placeholder filled at runtime.
   # "Device:" is auto-detected if omitted.
   system_prompt: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ spare-paw = "spare_paw.__main__:main"
 
 [project.optional-dependencies]
 tui = ["rich>=13.0", "textual>=1.0"]
-dev = ["pytest", "pytest-asyncio", "rich>=13.0"]
+dev = ["pytest", "pytest-asyncio", "pytest-timeout", "rich>=13.0", "textual>=1.0"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"

--- a/src/spare_paw/bot/backend.py
+++ b/src/spare_paw/bot/backend.py
@@ -6,19 +6,23 @@ all I/O to the python-telegram-bot library.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.constants import ChatAction, ParseMode
+from telegram.error import NetworkError, TimedOut
 
 from spare_paw.core.engine import split_text
 
 logger = logging.getLogger(__name__)
 
 _MAX_MESSAGE_LENGTH = 4096
+_SEND_ATTEMPTS = 3
+_RETRY_BASE_DELAY = 1.0  # seconds: 1s, 2s, 4s
 
 # ---------------------------------------------------------------------------
 # Markdown → Telegram HTML conversion
@@ -149,54 +153,92 @@ class TelegramBackend:
     def set_app_state(self, app_state: Any) -> None:
         self._application.bot_data["app_state"] = app_state
 
+    async def _retry_send(
+        self, attempt: Callable[[], Awaitable[None]], description: str,
+    ) -> None:
+        """Run *attempt*, retrying transient network errors with backoff.
+
+        Up to ``_SEND_ATTEMPTS`` tries with exponential backoff (1s, 2s, 4s).
+        On final failure, logs at ERROR and re-raises so callers know the
+        delivery failed.
+        """
+        for i in range(_SEND_ATTEMPTS):
+            try:
+                await attempt()
+                return
+            except (NetworkError, TimedOut) as exc:
+                if i + 1 >= _SEND_ATTEMPTS:
+                    logger.error(
+                        "Failed to deliver %s after %d attempts: %s",
+                        description, _SEND_ATTEMPTS, exc,
+                    )
+                    raise
+                delay = _RETRY_BASE_DELAY * 2**i
+                logger.warning(
+                    "Transient error delivering %s (attempt %d/%d), retrying in %.0fs: %s",
+                    description, i + 1, _SEND_ATTEMPTS, delay, exc,
+                )
+                await asyncio.sleep(delay)
+
     async def send_text(self, text: str) -> None:
         if not text:
             text = "(empty response)"
 
         chunks = split_text(text, _MAX_MESSAGE_LENGTH)
         for chunk in chunks:
-            try:
-                html = md_to_html(chunk)
-                await self.bot.send_message(
-                    chat_id=self._chat_id,
-                    text=html,
-                    parse_mode=ParseMode.HTML,
-                )
-            except Exception:
-                await self.bot.send_message(
-                    chat_id=self._chat_id,
-                    text=chunk,
-                )
+
+            async def _attempt(chunk: str = chunk) -> None:
+                try:
+                    html = md_to_html(chunk)
+                    await self.bot.send_message(
+                        chat_id=self._chat_id,
+                        text=html,
+                        parse_mode=ParseMode.HTML,
+                    )
+                except Exception:
+                    await self.bot.send_message(
+                        chat_id=self._chat_id,
+                        text=chunk,
+                    )
+
+            await self._retry_send(_attempt, f"text chunk ({len(chunk)} chars)")
 
     async def send_file(self, path: str, caption: str = "") -> None:
         fpath = Path(path)
         suffix = fpath.suffix.lower()
-        with open(fpath, "rb") as f:
-            if suffix in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
-                await self.bot.send_photo(
-                    chat_id=self._chat_id, photo=f, caption=caption or None,
-                )
-            elif suffix in (".mp4", ".mov", ".avi"):
-                await self.bot.send_video(
-                    chat_id=self._chat_id, video=f, caption=caption or None,
-                )
-            elif suffix in (".mp3", ".ogg", ".m4a", ".wav"):
-                await self.bot.send_audio(
-                    chat_id=self._chat_id, audio=f, caption=caption or None,
-                )
-            else:
-                await self.bot.send_document(
-                    chat_id=self._chat_id, document=f, caption=caption or None,
-                )
+
+        async def _attempt() -> None:
+            with open(fpath, "rb") as f:
+                if suffix in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
+                    await self.bot.send_photo(
+                        chat_id=self._chat_id, photo=f, caption=caption or None,
+                    )
+                elif suffix in (".mp4", ".mov", ".avi"):
+                    await self.bot.send_video(
+                        chat_id=self._chat_id, video=f, caption=caption or None,
+                    )
+                elif suffix in (".mp3", ".ogg", ".m4a", ".wav"):
+                    await self.bot.send_audio(
+                        chat_id=self._chat_id, audio=f, caption=caption or None,
+                    )
+                else:
+                    await self.bot.send_document(
+                        chat_id=self._chat_id, document=f, caption=caption or None,
+                    )
+
+        await self._retry_send(_attempt, f"file {fpath.name}")
 
     async def send_voice(self, ogg_bytes: bytes) -> None:
         """Send raw opus/ogg bytes as a Telegram voice note."""
         from telegram import InputFile
 
-        await self.bot.send_voice(
-            chat_id=self._chat_id,
-            voice=InputFile(ogg_bytes, filename="voice.ogg"),
-        )
+        async def _attempt() -> None:
+            await self.bot.send_voice(
+                chat_id=self._chat_id,
+                voice=InputFile(ogg_bytes, filename="voice.ogg"),
+            )
+
+        await self._retry_send(_attempt, f"voice note ({len(ogg_bytes)} bytes)")
 
     async def send_typing(self) -> None:
         await self.bot.send_chat_action(

--- a/src/spare_paw/config.py
+++ b/src/spare_paw/config.py
@@ -147,12 +147,28 @@ class Config:
         self._overrides: dict[str, Any] = {}
 
     def load(self, path: Path | None = None) -> None:
-        """Load config from YAML file, deep-merging with defaults."""
+        """Load config from YAML file, deep-merging with defaults.
+
+        Raises RuntimeError if the file is malformed YAML or does not contain
+        a mapping — fail fast rather than silently running without the file's
+        settings (it holds the API key).
+        """
         path = path or CONFIG_PATH
         with self._lock:
             if path.exists():
-                with open(path, "r") as f:
-                    file_data = yaml.safe_load(f) or {}
+                try:
+                    with open(path, "r") as f:
+                        file_data = yaml.safe_load(f) or {}
+                except yaml.YAMLError as exc:
+                    raise RuntimeError(
+                        f"Failed to parse config file {path}: {exc}\n"
+                        "Fix the YAML syntax (or restore the file from backup) and restart."
+                    ) from exc
+                if not isinstance(file_data, dict):
+                    raise RuntimeError(
+                        f"Config file {path} must contain a YAML mapping of settings, "
+                        f"got {type(file_data).__name__}. Fix the file and restart."
+                    )
                 self._data = _deep_merge(DEFAULTS, file_data)
             else:
                 self._data = copy.deepcopy(DEFAULTS)

--- a/src/spare_paw/config.py
+++ b/src/spare_paw/config.py
@@ -40,8 +40,19 @@ def _build_defaults() -> dict[str, Any]:
             "token_budget": 120000,
             "safety_margin": 0.85,
         },
+        "llm": {
+            # Concurrent LLM calls (main agent + subagents + consults). 1
+            # serializes everything and starves consults; keep it small but >1.
+            "max_concurrent": 4,
+        },
         "agent": {
             "max_tool_iterations": 20,
+            # Hard server-side caps for spawned subagents, regardless of what
+            # the model asks for.
+            "subagent_max_iterations_cap": 30,
+            "subagent_token_budget": 150000,
+            # Wall-clock ceiling for processing one queued message end-to-end.
+            "message_timeout_seconds": 600,
             "system_prompt": (
                 "You are a personal AI assistant running 24/7.\n"
                 "You have access to the local filesystem, shell, web search, and web scraping.\n"

--- a/src/spare_paw/context.py
+++ b/src/spare_paw/context.py
@@ -34,7 +34,7 @@ _encoder: tiktoken.Encoding | None = None
 
 # Per-conversation compaction failure counter (resets on success)
 _compact_consecutive_failures: dict[str, int] = {}
-_COMPACT_FAILURE_WARN_THRESHOLD: int = 3
+_COMPACT_FAILURE_ESCALATION_THRESHOLD: int = 3
 _COMPACT_RETRY_DELAY_SECONDS: float = 2
 
 
@@ -135,7 +135,14 @@ async def assemble(
         }
         # Restore tool_call metadata if present
         if row["metadata"]:
-            meta = json.loads(row["metadata"])
+            try:
+                meta = json.loads(row["metadata"])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Invalid JSON in messages.metadata for message %s — skipping metadata",
+                    row["id"],
+                )
+                meta = {}
             if "tool_call_id" in meta:
                 msg["tool_call_id"] = meta["tool_call_id"]
             if "tool_calls" in meta:
@@ -369,14 +376,20 @@ async def compact(
 
     # Find message IDs already covered by existing summary nodes
     async with db.execute(
-        "SELECT source_msg_ids FROM summary_nodes WHERE conversation_id = ? AND depth = 0",
+        "SELECT id, source_msg_ids FROM summary_nodes WHERE conversation_id = ? AND depth = 0",
         (conversation_id,),
     ) as cur:
         rows = await cur.fetchall()
 
     covered_ids: set[str] = set()
     for row in rows:
-        covered_ids.update(json.loads(row["source_msg_ids"]))
+        try:
+            covered_ids.update(json.loads(row["source_msg_ids"]))
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Invalid JSON in summary_nodes.source_msg_ids for node %s — treating as empty",
+                row["id"],
+            )
 
     # Filter to uncovered messages only
     uncovered = [
@@ -408,7 +421,8 @@ async def compact_with_retry(
 
     - On first failure: logs WARNING, waits before retrying once.
     - On retry failure: logs ERROR, skips compaction for this cycle.
-    - Tracks consecutive failures per conversation; logs WARNING at >= 3.
+    - Tracks consecutive failures per conversation (module-level
+      _compact_consecutive_failures); escalates to a distinct ERROR at >= 3.
     - Resets the failure counter on success.
     - Source messages are never deleted on failure. Partial summary nodes
       may persist from a failed attempt; the next successful compaction
@@ -438,10 +452,11 @@ async def compact_with_retry(
             "skipping this cycle (consecutive failures: %d)",
             conversation_id, exc, count,
         )
-        if count >= _COMPACT_FAILURE_WARN_THRESHOLD:
-            logger.warning(
-                "LCM compaction has failed %d+ times consecutively for conversation %s",
-                _COMPACT_FAILURE_WARN_THRESHOLD, conversation_id,
+        if count >= _COMPACT_FAILURE_ESCALATION_THRESHOLD:
+            logger.error(
+                "LCM compaction has failed %d times consecutively for conversation %s — "
+                "compression is stalled and context will keep growing; needs attention",
+                count, conversation_id,
             )
 
 
@@ -540,21 +555,31 @@ async def _condense_summaries(
     leaf_ids = [leaf["id"] for leaf in leaves]
     source_ids = json.dumps(leaf_ids)
 
-    await db.execute(
-        """INSERT INTO summary_nodes
-           (id, conversation_id, parent_id, depth, content, token_count, source_msg_ids, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-        (node_id, conversation_id, None, 1, condensed_text, token_count, source_ids, now),
-    )
-
-    # Update leaf nodes to point to the new parent
-    for leaf_id in leaf_ids:
+    # The shared aiosqlite connection uses sqlite3's implicit-transaction mode
+    # (isolation_level=""), so without an explicit transaction a crash between
+    # the INSERT and the UPDATEs would leave a pending orphaned condensed node
+    # that the next unrelated commit on the connection would persist. Make the
+    # multi-step write explicitly atomic.
+    await db.execute("BEGIN IMMEDIATE")
+    try:
         await db.execute(
-            "UPDATE summary_nodes SET parent_id = ? WHERE id = ?",
-            (node_id, leaf_id),
+            """INSERT INTO summary_nodes
+               (id, conversation_id, parent_id, depth, content, token_count, source_msg_ids, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (node_id, conversation_id, None, 1, condensed_text, token_count, source_ids, now),
         )
 
-    await db.commit()
+        # Update leaf nodes to point to the new parent
+        for leaf_id in leaf_ids:
+            await db.execute(
+                "UPDATE summary_nodes SET parent_id = ? WHERE id = ?",
+                (node_id, leaf_id),
+            )
+
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
 
     logger.debug(
         "Condensed %d leaves into node %s (depth=1) for conversation %s",

--- a/src/spare_paw/core/engine.py
+++ b/src/spare_paw/core/engine.py
@@ -21,7 +21,7 @@ from spare_paw.core.prompt import build_system_prompt
 from spare_paw.core.vision import describe_media
 from spare_paw.core.voice import VoiceTranscriptionError
 from spare_paw.core.voice_out import VoiceRenderError, render_voice_note
-from spare_paw.router.tool_loop import run_tool_loop
+from spare_paw.router.tool_loop import coerce_loop_result, run_tool_loop
 
 if TYPE_CHECKING:
     from spare_paw.backend import IncomingMessage, MessageBackend
@@ -84,6 +84,13 @@ async def process_message(
             text = await voice_module.transcribe(msg.voice_bytes, config_data)
         except VoiceTranscriptionError:
             logger.exception("Voice transcription failed")
+            try:
+                await backend.send_text(
+                    "⚠️ I couldn't transcribe that voice note — mind typing it "
+                    "or sending it again?"
+                )
+            except Exception:
+                logger.exception("Failed to send transcription-failure notice")
             return
 
     # 2. Vision preprocessing for images/videos
@@ -164,7 +171,7 @@ async def process_message(
     tool_schemas = app_state.tool_registry.get_schemas()
     max_iterations = app_state.config.get("agent.max_tool_iterations", 20)
 
-    response_text = await run_tool_loop(
+    loop_result = coerce_loop_result(await run_tool_loop(
         client=app_state.router_client,
         messages=messages,
         model=model,
@@ -172,9 +179,21 @@ async def process_message(
         tool_registry=app_state.tool_registry,
         max_iterations=max_iterations,
         executor=app_state.executor,
+        return_result=True,
         on_event=on_event,
         on_token=on_token,
-    )
+    ))
+    response_text = loop_result.text
+
+    if not loop_result.ok:
+        # Loop-level failure — tell the user honestly, but never record the
+        # diagnostic as an assistant reply in conversation history.
+        logger.error("Turn failed (outcome=%s): %s", loop_result.outcome, response_text)
+        try:
+            await backend.send_text(f"⚠️ I hit a problem with that: {response_text}")
+        except Exception:
+            logger.exception("Failed to send turn-failure notice")
+        return
 
     # 9. Ingest assistant response
     await ctx.ingest(conversation_id, "assistant", response_text)
@@ -262,10 +281,15 @@ async def process_agent_callback(
         messages = await ctx.assemble(conversation_id, system_prompt)
 
         model = resolve_model(app_state.config, "main_agent")
-        tool_schemas = app_state.tool_registry.get_schemas()
+        # The synthesis turn must not spawn more agents — completed agents
+        # triggering new spawns would allow unbounded agent chains.
+        tool_schemas = [
+            s for s in app_state.tool_registry.get_schemas()
+            if s.get("function", {}).get("name") != "spawn_agent"
+        ]
         max_iterations = app_state.config.get("agent.max_tool_iterations", 20)
 
-        response_text = await run_tool_loop(
+        loop_result = coerce_loop_result(await run_tool_loop(
             client=app_state.router_client,
             messages=messages,
             model=model,
@@ -273,7 +297,20 @@ async def process_agent_callback(
             tool_registry=app_state.tool_registry,
             max_iterations=max_iterations,
             executor=app_state.executor,
-        )
+            return_result=True,
+        ))
+        response_text = loop_result.text
+
+        if not loop_result.ok:
+            logger.error(
+                "Agent-callback synthesis failed (outcome=%s)", loop_result.outcome,
+            )
+            await backend.send_text(
+                "⚠️ Your background agents finished, but I hit a problem "
+                f"writing up the results: {response_text}\n"
+                "The raw results are saved — ask me to look them up."
+            )
+            return
 
         await ctx.ingest(conversation_id, "assistant", response_text)
         await backend.send_text(response_text)
@@ -302,6 +339,15 @@ async def enqueue(item: IncomingMessage | tuple) -> None:
         logger.error("enqueue() called but queue not initialized — item DROPPED: %s", type(item))
 
 
+def queue_healthy() -> bool:
+    """True while the queue consumer task is alive (or not started yet).
+
+    The gateway heartbeat gates the systemd watchdog ping on this, so a dead
+    consumer no longer looks like a healthy process.
+    """
+    return _queue_task is None or not _queue_task.done()
+
+
 def start_queue_processor(app_state: Any, backend: MessageBackend) -> None:
     """Start the background task that drains the message queue."""
     global _message_queue, _queue_task
@@ -316,32 +362,144 @@ def start_queue_processor(app_state: Any, backend: MessageBackend) -> None:
     logger.info("Message queue processor started")
 
 
-async def _process_queue(app_state: Any, backend: MessageBackend) -> None:
-    """Drain the message queue, processing one message at a time."""
+async def stop_queue_processor(drain_timeout: float = 8.0) -> None:
+    """Drain outstanding queue items (bounded), then cancel the consumer."""
+    global _queue_task
+    if _message_queue is not None:
+        try:
+            await asyncio.wait_for(_message_queue.join(), timeout=drain_timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Queue not drained after %.0fs — cancelling with %d item(s) pending",
+                drain_timeout, _message_queue.qsize(),
+            )
+    if _queue_task is not None and not _queue_task.done():
+        _queue_task.cancel()
+        try:
+            await _queue_task
+        except asyncio.CancelledError:
+            pass
+    logger.info("Message queue processor stopped")
+
+
+async def _mark_callback_delivered(callback_id: int) -> None:
+    """Flag a persisted agent callback as delivered (best-effort)."""
+    try:
+        from spare_paw.db import get_db, is_initialized
+        if not is_initialized():
+            return
+        db = await get_db()
+        await db.execute(
+            "UPDATE agent_callbacks SET delivered = 1 WHERE id = ?", (callback_id,)
+        )
+        await db.commit()
+    except Exception:
+        logger.exception("Failed to mark callback %s delivered", callback_id)
+
+
+async def recover_orphans(app_state: Any, backend: MessageBackend) -> None:
+    """Startup reconciliation after a restart.
+
+    Marks agents that were running when the process died as interrupted (and
+    tells the user which ones), then re-enqueues any persisted callbacks that
+    were never processed.
+    """
+    try:
+        from spare_paw.db import get_db, is_initialized
+        if not is_initialized():
+            return
+        db = await get_db()
+
+        async with db.execute(
+            "SELECT id, name FROM agents WHERE status IN ('starting', 'running')"
+        ) as cur:
+            orphans = await cur.fetchall()
+        if orphans:
+            now = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
+            await db.execute(
+                "UPDATE agents SET status = 'interrupted', "
+                "error = 'Interrupted by restart', finished_at = ? "
+                "WHERE status IN ('starting', 'running')",
+                (now,),
+            )
+            await db.commit()
+            names = ", ".join(row["name"] or row["id"] for row in orphans)
+            logger.warning("Recovered %d orphaned agent(s): %s", len(orphans), names)
+            try:
+                await backend.send_text(
+                    f"⚠️ A restart interrupted {len(orphans)} background "
+                    f"agent(s): {names}. Ask me again if you still need them."
+                )
+            except Exception:
+                logger.exception("Failed to send orphan-recovery notice")
+
+        async with db.execute(
+            "SELECT id, payload FROM agent_callbacks WHERE delivered = 0"
+        ) as cur:
+            pending = await cur.fetchall()
+        for row in pending:
+            logger.info("Re-enqueueing undelivered agent callback %d", row["id"])
+            await enqueue(("agent_callback", row["payload"], row["id"]))
+    except Exception:
+        logger.exception("Orphan recovery failed")
+
+
+async def _handle_queue_item(
+    app_state: Any, item: Any, backend: MessageBackend
+) -> None:
+    """Process one queue item with a wall-clock ceiling and error reporting."""
     from spare_paw.backend import IncomingMessage as _IncomingMessage
 
+    try:
+        timeout_s = float(app_state.config.get("agent.message_timeout_seconds", 600) or 600)
+    except (TypeError, ValueError):
+        timeout_s = 600.0
+
+    try:
+        if isinstance(item, tuple) and len(item) >= 2 and item[0] == "agent_callback":
+            await asyncio.wait_for(
+                process_agent_callback(app_state, item[1], backend),
+                timeout=timeout_s,
+            )
+            if len(item) > 2 and item[2] is not None:
+                await _mark_callback_delivered(item[2])
+        elif isinstance(item, _IncomingMessage):
+            # Start typing indicator
+            await backend.send_typing()
+            await asyncio.wait_for(
+                process_message(app_state, item, backend),
+                timeout=timeout_s,
+            )
+        else:
+            logger.warning("Unknown item type in queue: %s", type(item))
+    except asyncio.TimeoutError:
+        logger.error("Queue item timed out after %.0fs: %s", timeout_s, type(item))
+        try:
+            await backend.send_text(
+                "⚠️ That took too long and I had to stop. Try again, or break "
+                "it into smaller steps."
+            )
+        except Exception:
+            logger.exception("Failed to send timeout notice")
+    except Exception:
+        logger.exception("Unhandled error processing queue item")
+        try:
+            await backend.send_text(
+                "An internal error occurred. Please try again."
+            )
+        except Exception:
+            logger.exception("Failed to send error reply")
+
+
+async def _process_queue(app_state: Any, backend: MessageBackend) -> None:
+    """Drain the message queue, processing one message at a time."""
     assert _message_queue is not None
 
     while True:
         try:
             item = await _message_queue.get()
             try:
-                if isinstance(item, tuple) and len(item) == 2 and item[0] == "agent_callback":
-                    await process_agent_callback(app_state, item[1], backend)
-                elif isinstance(item, _IncomingMessage):
-                    # Start typing indicator
-                    await backend.send_typing()
-                    await process_message(app_state, item, backend)
-                else:
-                    logger.warning("Unknown item type in queue: %s", type(item))
-            except Exception:
-                logger.exception("Unhandled error processing queue item")
-                try:
-                    await backend.send_text(
-                        "An internal error occurred. Please try again."
-                    )
-                except Exception:
-                    logger.exception("Failed to send error reply")
+                await _handle_queue_item(app_state, item, backend)
             finally:
                 _message_queue.task_done()
         except asyncio.CancelledError:

--- a/src/spare_paw/cron/executor.py
+++ b/src/spare_paw/cron/executor.py
@@ -33,6 +33,8 @@ async def execute_cron(
     """Execute a cron job: run the prompt through the tool loop and send the result to the owner.
 
     Steps:
+        0. Claim one-shot (once=true) crons: delete the row BEFORE running so
+           a crash after execution can never fire them twice (claim-then-run).
         1. Resolve model (cron-specific → cron_default → default).
         2. Build messages with system prompt + user prompt.
         3. Get tool schemas, filtered by tools_allowed if set.
@@ -42,30 +44,30 @@ async def execute_cron(
     """
     now = datetime.now(timezone.utc).isoformat()
 
-    # Check if this is a dream cron — handle it directly without the full tool loop
-    try:
-        db = await get_db()
-        cursor = await db.execute(
-            "SELECT metadata FROM cron_jobs WHERE id = ?", (cron_id,)
-        )
-        row = await cursor.fetchone()
-        metadata_str = row["metadata"] if row else None
-        metadata = json.loads(metadata_str) if metadata_str else {}
-        if metadata.get("dream"):
-            from spare_paw.tools.dream import run_dream
-
-            result = await run_dream(app_state)
-            # Send result notification
-            backend = getattr(app_state, "backend", None)
-            if backend is not None:
-                await backend.send_text(result)
-            await _update_cron_result(cron_id, now, result=result)
-            logger.info("Dream cron %s executed successfully", cron_id)
-            return
-    except Exception as exc:
-        logger.debug("Dream cron check failed for %s: %s", cron_id, exc, exc_info=True)
+    # Claim one-shot crons BEFORE any work executes.  once is None when the
+    # row is already gone (consumed by a previous run or deleted) — skip.
+    once, metadata = await _claim_one_shot(cron_id)
+    if once is None:
+        logger.info("Cron %s row already gone, skipping execution", cron_id)
+        return
 
     try:
+        # Check if this is a dream cron — handle it directly without the full tool loop
+        try:
+            if metadata.get("dream"):
+                from spare_paw.tools.dream import run_dream
+
+                result = await run_dream(app_state)
+                # Send result notification
+                backend = getattr(app_state, "backend", None)
+                if backend is not None:
+                    await backend.send_text(result)
+                await _update_cron_result(cron_id, now, result=result)
+                logger.info("Dream cron %s executed successfully", cron_id)
+                return
+        except Exception as exc:
+            logger.debug("Dream cron check failed for %s: %s", cron_id, exc, exc_info=True)
+
         # 1. Resolve model (per-job override → cron role → main_agent)
         resolved_model = model or resolve_model(app_state.config, "cron")
 
@@ -144,8 +146,10 @@ async def execute_cron(
         await _update_cron_result(cron_id, now, error=error_msg)
 
     finally:
-        # Auto-delete one-shot crons regardless of success/failure
-        await _maybe_delete_once(app_state, cron_id)
+        # One-shot crons: the DB row was already consumed by the claim above;
+        # remove the job from the running scheduler regardless of outcome.
+        if once:
+            await _remove_one_shot_from_scheduler(app_state, cron_id)
 
 
 async def _update_cron_result(
@@ -172,21 +176,46 @@ async def _update_cron_result(
         logger.exception("Failed to update cron_jobs for %s", cron_id)
 
 
-async def _maybe_delete_once(app_state: Any, cron_id: str) -> None:
-    """Delete a cron job if it has once=true in its metadata."""
+async def _claim_one_shot(cron_id: str) -> tuple[bool | None, dict[str, Any]]:
+    """Claim a one-shot cron before execution (claim-then-run).
+
+    One-shot (once=true) rows are deleted BEFORE the job's work runs, so a
+    crash after execution — or a restart mid-run — can never fire them twice.
+
+    Returns (once, metadata):
+        (False, metadata) — not a one-shot job, proceed normally.
+        (True, metadata)  — one-shot job claimed (row deleted), this call owns the run.
+        (None, {})        — row already gone or claim lost, skip execution.
+    """
     try:
         db = await get_db()
         cursor = await db.execute(
             "SELECT metadata FROM cron_jobs WHERE id = ?", (cron_id,)
         )
         row = await cursor.fetchone()
-        if row and row["metadata"]:
-            meta = json.loads(row["metadata"])
-            if meta.get("once"):
-                await db.execute("DELETE FROM cron_jobs WHERE id = ?", (cron_id,))
-                await db.commit()
-                if app_state.scheduler:
-                    await app_state.scheduler.remove_job(cron_id)
-                logger.info("One-shot cron %s auto-deleted", cron_id)
+        if row is None:
+            return None, {}
+        metadata = json.loads(row["metadata"]) if row["metadata"] else {}
+        if not metadata.get("once"):
+            return False, metadata
+        cursor = await db.execute("DELETE FROM cron_jobs WHERE id = ?", (cron_id,))
+        await db.commit()
+        if cursor.rowcount == 0:
+            # Another run claimed the row between the SELECT and the DELETE.
+            return None, {}
+        logger.info("One-shot cron %s claimed (row deleted before run)", cron_id)
+        return True, metadata
     except Exception:
-        logger.exception("Failed to auto-delete one-shot cron %s", cron_id)
+        logger.exception("Failed to claim one-shot cron %s", cron_id)
+        return False, {}
+
+
+async def _remove_one_shot_from_scheduler(app_state: Any, cron_id: str) -> None:
+    """Remove a consumed one-shot cron from the running scheduler."""
+    try:
+        scheduler = getattr(app_state, "scheduler", None)
+        if scheduler:
+            await scheduler.remove_job(cron_id)
+        logger.info("One-shot cron %s removed after run", cron_id)
+    except Exception:
+        logger.exception("Failed to remove one-shot cron %s from scheduler", cron_id)

--- a/src/spare_paw/cron/scheduler.py
+++ b/src/spare_paw/cron/scheduler.py
@@ -8,8 +8,9 @@ keep the scheduler and database in sync.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, tzinfo
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -29,6 +30,29 @@ class CronScheduler:
         self._app_state = app_state
         self._scheduler: AsyncIOScheduler | None = None
 
+    def _resolve_timezone(self) -> tzinfo:
+        """Resolve the cron timezone: cron.timezone from config, else system local.
+
+        Always explicit so cron firing times never silently depend on the
+        implicit process timezone.
+        """
+        tz_name = None
+        config = getattr(self._app_state, "config", None)
+        if config is not None:
+            try:
+                tz_name = config.get("cron.timezone")
+            except Exception:
+                tz_name = None
+        if isinstance(tz_name, str) and tz_name:
+            try:
+                return ZoneInfo(tz_name)
+            except Exception:
+                logger.warning(
+                    "Invalid cron.timezone %r; falling back to system local timezone",
+                    tz_name,
+                )
+        return datetime.now().astimezone().tzinfo
+
     async def start(self) -> None:
         """Create the scheduler, load all enabled crons from DB, and start."""
         self._scheduler = AsyncIOScheduler()
@@ -39,6 +63,8 @@ class CronScheduler:
             "FROM cron_jobs WHERE enabled = 1"
         ) as cursor:
             rows = await cursor.fetchall()
+
+        tz = self._resolve_timezone()
 
         for row in rows:
             cron_id = row["id"]
@@ -58,13 +84,19 @@ class CronScheduler:
                     tools_list = None
 
             try:
-                trigger = CronTrigger.from_crontab(schedule)
+                trigger = CronTrigger.from_crontab(schedule, timezone=tz)
                 self._scheduler.add_job(
                     self._run_cron,
                     trigger=trigger,
                     id=cron_id,
                     args=[cron_id, prompt, model, tools_list],
                     replace_existing=True,
+                    # A job missed while the process was down (up to 1h) runs
+                    # once on restart instead of being dropped or replayed N times.
+                    misfire_grace_time=3600,
+                    coalesce=True,
+                    # A slow run must not overlap with the next firing.
+                    max_instances=1,
                 )
                 logger.info("Scheduled cron %s (%s)", cron_id, schedule)
             except (ValueError, TypeError) as exc:
@@ -102,13 +134,19 @@ class CronScheduler:
         if self._scheduler is None:
             raise RuntimeError("Scheduler is not running")
 
-        trigger = CronTrigger.from_crontab(schedule)
+        trigger = CronTrigger.from_crontab(schedule, timezone=self._resolve_timezone())
         self._scheduler.add_job(
             self._run_cron,
             trigger=trigger,
             id=cron_id,
             args=[cron_id, prompt, model, tools_allowed],
             replace_existing=True,
+            # A job missed while the process was down (up to 1h) runs
+            # once on restart instead of being dropped or replayed N times.
+            misfire_grace_time=3600,
+            coalesce=True,
+            # A slow run must not overlap with the next firing.
+            max_instances=1,
         )
         logger.info("Added cron job %s (%s)", cron_id, schedule)
 

--- a/src/spare_paw/db.py
+++ b/src/spare_paw/db.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 DB_DIR = Path.home() / ".spare-paw"
 DB_PATH = DB_DIR / "spare-paw.db"
 
-CURRENT_SCHEMA_VERSION = 3
+CURRENT_SCHEMA_VERSION = 4
 
 SCHEMA_V1 = """\
 CREATE TABLE IF NOT EXISTS messages (
@@ -137,9 +137,45 @@ CREATE TRIGGER IF NOT EXISTS summary_nodes_au AFTER UPDATE ON summary_nodes BEGI
 END;
 """
 
+SCHEMA_V4 = """\
+CREATE TABLE IF NOT EXISTS agents (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    group_id TEXT,
+    agent_type TEXT,
+    status TEXT NOT NULL,
+    prompt TEXT,
+    result TEXT,
+    error TEXT,
+    usage TEXT,
+    created_at TEXT,
+    finished_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agents_group ON agents(group_id);
+CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
+
+CREATE TABLE IF NOT EXISTS agent_callbacks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id TEXT,
+    payload TEXT NOT NULL,
+    delivered INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+"""
+
 # ---- Singleton connection ----
 
 _connection: aiosqlite.Connection | None = None
+
+
+def is_initialized() -> bool:
+    """True once the shared connection exists (init_db/get_db has run).
+
+    Best-effort persistence helpers use this to avoid implicitly creating
+    a database in contexts that never initialized one (e.g. unit tests).
+    """
+    return _connection is not None
 
 
 async def get_db() -> aiosqlite.Connection:
@@ -188,6 +224,13 @@ async def init_db() -> None:
         await _set_user_version(conn, 3)
         await conn.commit()
         logger.info("Database schema v3 applied")
+
+    if version < 4:
+        logger.info("Migrating database to schema v4 (agents, agent_callbacks)")
+        await conn.executescript(SCHEMA_V4)
+        await _set_user_version(conn, 4)
+        await conn.commit()
+        logger.info("Database schema v4 applied")
 
 
 async def close_db() -> None:

--- a/src/spare_paw/gateway.py
+++ b/src/spare_paw/gateway.py
@@ -130,7 +130,14 @@ def _sd_notify(message: str) -> None:
 
 
 async def _heartbeat() -> None:
-    """Touch the heartbeat file and ping systemd watchdog every 30 seconds."""
+    """Touch the heartbeat file and ping systemd watchdog every 30 seconds.
+
+    The watchdog ping is gated on the message-queue consumer being alive:
+    liveness must reflect the component that actually serves the user, not
+    just the event loop.
+    """
+    from spare_paw.core import engine as engine_mod
+
     while True:
         try:
             HEARTBEAT_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -139,7 +146,12 @@ async def _heartbeat() -> None:
             )
         except OSError:
             logger.exception("Failed to write heartbeat file")
-        _sd_notify("WATCHDOG=1")
+        if engine_mod.queue_healthy():
+            _sd_notify("WATCHDOG=1")
+        else:
+            logger.error(
+                "Queue processor is dead — withholding systemd watchdog ping"
+            )
         await asyncio.sleep(30)
 
 
@@ -156,7 +168,10 @@ async def init_app_state() -> AppState:
     await init_db()
 
     executor = ProcessPoolExecutor(max_workers=4)
-    semaphore = asyncio.Semaphore(1)
+    # Bounded LLM concurrency. 1 would serialize the main agent, every
+    # subagent, and consult answers behind each other — consults would time
+    # out structurally and "parallel" agents would run sequentially.
+    semaphore = asyncio.Semaphore(int(config.get("llm.max_concurrent", 4)))
 
     from spare_paw.router.openrouter import OpenRouterClient
 
@@ -427,8 +442,13 @@ async def _async_main() -> None:
         logger.info("Webhook API listening on port %d", config.get("webhook.port", 8080))
 
     # 16. Start message queue processor (must be after initialize/start)
+    from spare_paw.core.engine import recover_orphans as _recover_orphans
     from spare_paw.core.engine import start_queue_processor as _start_queue
     _start_queue(app_state, backend)
+
+    # 17. Reconcile state from before the last shutdown/crash: mark orphaned
+    # agents interrupted and re-enqueue undelivered agent callbacks.
+    await _recover_orphans(app_state, backend)
 
     logger.info("Bot started (%s backend)", backend_type)
     _sd_notify("READY=1")
@@ -437,8 +457,32 @@ async def _async_main() -> None:
     await shutdown_event.wait()
 
     # ---- Graceful shutdown ----
+    # Ordering matters: stop producing work (cron), cancel agents (their
+    # finally blocks persist state), drain the queue, and only then tear
+    # down the resources those tasks depend on (clients, DB).
     logger.info("Shutting down...")
     _sd_notify("STOPPING=1")
+
+    # Stop cron scheduler — no new work
+    if app_state.scheduler is not None:
+        try:
+            await app_state.scheduler.stop()
+        except Exception:
+            logger.exception("Error shutting down scheduler")
+
+    # Cancel running subagents; they record status "interrupted" for recovery
+    from spare_paw.tools import subagent as _subagent_mod
+    try:
+        await _subagent_mod.shutdown()
+    except Exception:
+        logger.exception("Error shutting down subagents")
+
+    # Drain outstanding queue items (bounded), then stop the consumer
+    from spare_paw.core.engine import stop_queue_processor as _stop_queue
+    try:
+        await _stop_queue()
+    except Exception:
+        logger.exception("Error stopping queue processor")
 
     heartbeat_task.cancel()
     try:
@@ -449,13 +493,6 @@ async def _async_main() -> None:
     # Close browser session
     from spare_paw.tools import browser as _browser_mod
     await _browser_mod.shutdown()
-
-    # Stop cron scheduler
-    if app_state.scheduler is not None:
-        try:
-            await app_state.scheduler.stop()
-        except Exception:
-            logger.exception("Error shutting down scheduler")
 
     # Close MCP client
     if app_state.mcp_client is not None:

--- a/src/spare_paw/router/openrouter.py
+++ b/src/spare_paw/router/openrouter.py
@@ -61,6 +61,12 @@ class OpenRouterClient:
         self._models_cache: list[dict[str, Any]] | None = None
         self._models_cache_time: float = 0
 
+    @property
+    def semaphore(self) -> asyncio.Semaphore:
+        """The shared LLM-call semaphore, for callers that need to acquire it
+        themselves (e.g. to exclude queueing time from their own timeouts)."""
+        return self._semaphore
+
     def _get_session(self) -> aiohttp.ClientSession:
         """Lazily create and return the aiohttp session."""
         if self._session is None or self._session.closed:
@@ -172,8 +178,14 @@ class OpenRouterClient:
         messages: list[dict[str, Any]],
         model: str,
         tools: list[dict[str, Any]] | None = None,
+        *,
+        semaphore_held: bool = False,
     ) -> AsyncIterator[StreamChunk]:
-        """Yield structured StreamChunk events via OpenRouter SSE."""
+        """Yield structured StreamChunk events via OpenRouter SSE.
+
+        Pass ``semaphore_held=True`` when the caller already holds
+        :attr:`semaphore` (avoids a deadlock-prone double acquire).
+        """
         body: dict[str, Any] = {
             "model": model,
             "messages": messages,
@@ -183,52 +195,62 @@ class OpenRouterClient:
             body["tools"] = tools
             body["tool_choice"] = "auto"
 
-        session = self._get_session()
+        if semaphore_held:
+            async for chunk in self._stream_request(body):
+                yield chunk
+            return
+
         async with self._semaphore:
-            async with session.post(OPENROUTER_URL, json=body) as resp:
-                if resp.status >= 400:
-                    text = await resp.text()
-                    raise OpenRouterError(resp.status, text)
+            async for chunk in self._stream_request(body):
+                yield chunk
 
-                async for line in resp.content:
-                    decoded = line.decode("utf-8").strip()
-                    if not decoded.startswith("data: "):
-                        continue
-                    payload = decoded[6:]
-                    if payload == "[DONE]":
-                        return
-                    try:
-                        chunk_data = json.loads(payload)
-                    except json.JSONDecodeError:
-                        continue
+    async def _stream_request(self, body: dict[str, Any]) -> AsyncIterator[StreamChunk]:
+        """Execute one SSE streaming request and yield parsed chunks."""
+        session = self._get_session()
+        async with session.post(OPENROUTER_URL, json=body) as resp:
+            if resp.status >= 400:
+                text = await resp.text()
+                raise OpenRouterError(resp.status, text)
 
-                    choices = chunk_data.get("choices") or []
-                    if not choices:
-                        continue
-                    choice = choices[0]
-                    delta = choice.get("delta") or {}
-                    finish_reason = choice.get("finish_reason")
+            async for line in resp.content:
+                decoded = line.decode("utf-8").strip()
+                if not decoded.startswith("data: "):
+                    continue
+                payload = decoded[6:]
+                if payload == "[DONE]":
+                    return
+                try:
+                    chunk_data = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
 
-                    content = delta.get("content")
-                    if content:
-                        yield StreamChunk(kind="text_delta", content=content)
+                choices = chunk_data.get("choices") or []
+                if not choices:
+                    continue
+                choice = choices[0]
+                delta = choice.get("delta") or {}
+                finish_reason = choice.get("finish_reason")
 
-                    for tc in delta.get("tool_calls") or []:
-                        fn = tc.get("function") or {}
-                        yield StreamChunk(
-                            kind="tool_call_delta",
-                            tool_index=tc.get("index"),
-                            tool_id=tc.get("id"),
-                            tool_name=fn.get("name"),
-                            arguments_fragment=fn.get("arguments"),
-                        )
+                content = delta.get("content")
+                if content:
+                    yield StreamChunk(kind="text_delta", content=content)
 
-                    if finish_reason is not None:
-                        yield StreamChunk(
-                            kind="done",
-                            finish_reason=finish_reason,
-                            usage=chunk_data.get("usage"),
-                        )
+                for tc in delta.get("tool_calls") or []:
+                    fn = tc.get("function") or {}
+                    yield StreamChunk(
+                        kind="tool_call_delta",
+                        tool_index=tc.get("index"),
+                        tool_id=tc.get("id"),
+                        tool_name=fn.get("name"),
+                        arguments_fragment=fn.get("arguments"),
+                    )
+
+                if finish_reason is not None:
+                    yield StreamChunk(
+                        kind="done",
+                        finish_reason=finish_reason,
+                        usage=chunk_data.get("usage"),
+                    )
 
     async def list_models(self, force_refresh: bool = False) -> list[dict[str, Any]]:
         """Fetch available models from the OpenRouter models endpoint.

--- a/src/spare_paw/router/tool_loop.py
+++ b/src/spare_paw/router/tool_loop.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import time
 import uuid
 from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -25,6 +26,7 @@ async def _stream_and_assemble(
     model: str,
     tools: list[dict[str, Any]] | None,
     on_token: Callable[[str], None] | None,
+    semaphore_held: bool = False,
 ) -> tuple[dict[str, Any], dict[str, int]]:
     """Consume a streaming chat completion and return (assistant_message, usage).
 
@@ -35,7 +37,11 @@ async def _stream_and_assemble(
     tool_calls_by_index: dict[int, dict[str, Any]] = {}
     usage: dict[str, int] = {}
 
-    async for chunk in client.chat_stream(messages, model, tools):
+    stream_kwargs: dict[str, Any] = {}
+    if semaphore_held:
+        stream_kwargs["semaphore_held"] = True
+
+    async for chunk in client.chat_stream(messages, model, tools, **stream_kwargs):
         if chunk.kind == "text_delta" and chunk.content:
             text_parts.append(chunk.content)
             if on_token is not None:
@@ -76,6 +82,48 @@ class ToolEvent:
     result_preview: str | None = None
     iteration: int = 0
 
+
+# Loop outcomes. Anything other than OUTCOME_OK means ``text`` is a diagnostic
+# message, not a model reply — callers must not present it as a normal answer.
+OUTCOME_OK = "ok"
+OUTCOME_LLM_TIMEOUT = "llm_timeout"
+OUTCOME_BUDGET_EXHAUSTED = "budget_exhausted"
+OUTCOME_MAX_ITERATIONS = "max_iterations"
+
+
+@dataclass
+class ToolLoopResult:
+    """Structured result of a tool loop run: final text plus how it ended."""
+
+    text: str
+    outcome: str = OUTCOME_OK
+    usage: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.outcome == OUTCOME_OK
+
+
+def coerce_loop_result(value: Any) -> ToolLoopResult:
+    """Normalize any historical run_tool_loop return shape into a ToolLoopResult.
+
+    Accepts a ToolLoopResult (passed through), a ``(text, usage)`` tuple
+    (track_usage mode), or a bare string — the latter two are assumed OK.
+    """
+    if isinstance(value, ToolLoopResult):
+        return value
+    if isinstance(value, tuple) and len(value) == 2:
+        return ToolLoopResult(text=value[0], usage=dict(value[1] or {}))
+    return ToolLoopResult(text=value if isinstance(value, str) else str(value))
+
+
+# Per-tool overrides of the generic tool timeout. consult_main needs a full
+# main-agent LLM round-trip (semaphore wait + retries), so the generic
+# tool_timeout would kill it structurally under load.
+TOOL_TIMEOUT_OVERRIDES: dict[str, float] = {
+    "consult_main": 180.0,
+}
+
 # Per-turn (not per-session) call limits. Tools not listed are unlimited.
 DEFAULT_TOOL_LIMITS: dict[str, int] = {
     "web_scrape": 5,
@@ -106,7 +154,8 @@ async def run_tool_loop(
     tool_timeout: float = 60.0,
     llm_timeout: float = 120.0,
     token_budget: int = 0,
-) -> str | tuple[str, dict[str, int]]:
+    return_result: bool = False,
+) -> str | tuple[str, dict[str, int]] | ToolLoopResult:
     """Run the model in a tool-calling loop until it produces a final text response.
 
     Each iteration:
@@ -137,12 +186,17 @@ async def run_tool_loop(
             (default 120s). Prevents stuck API calls.
         token_budget: Maximum cumulative tokens for the entire loop. 0 means
             no limit. When exceeded, the loop aborts with a message.
+        return_result: If True, return a :class:`ToolLoopResult` carrying the
+            text, the accumulated usage, and an ``outcome`` marker that
+            distinguishes real replies from loop-level failures. Takes
+            precedence over ``track_usage``.
 
     Returns:
         The final text content from the model when ``track_usage`` is False.
         A tuple of ``(text, usage_dict)`` when ``track_usage`` is True, where
         *usage_dict* has keys ``prompt_tokens``, ``completion_tokens``, and
-        ``total_tokens``.
+        ``total_tokens``. A :class:`ToolLoopResult` when ``return_result``
+        is True.
     """
     merged = {**DEFAULT_TOOL_LIMITS, **(tool_limits or {})}
     effective_limits: dict[str, int] = {
@@ -161,10 +215,17 @@ async def run_tool_loop(
         for key in total_usage:
             total_usage[key] += usage.get(key, 0)
 
-    def _maybe_with_usage(text: str) -> str | tuple[str, dict[str, int]]:
+    def _finish(text: str, outcome: str) -> str | tuple[str, dict[str, int]] | ToolLoopResult:
+        if return_result:
+            return ToolLoopResult(text=text, outcome=outcome, usage=total_usage)
         if track_usage:
             return (text, total_usage)
         return text
+
+    # The client's semaphore serializes LLM calls; acquire it OUTSIDE the
+    # llm_timeout window so queueing behind other calls doesn't masquerade
+    # as an API timeout. Fake clients in tests have no semaphore attribute.
+    llm_semaphore = getattr(client, "semaphore", None)
 
     for iteration in range(1, max_iterations + 1):
         # Token budget circuit breaker
@@ -175,9 +236,10 @@ async def run_tool_loop(
                 token_budget,
                 iteration,
             )
-            return _maybe_with_usage(
+            return _finish(
                 f"Stopped: token budget exceeded ({total_usage['total_tokens']:,}/{token_budget:,} tokens). "
-                "Try a simpler approach or break the task into smaller steps."
+                "Try a simpler approach or break the task into smaller steps.",
+                OUTCOME_BUDGET_EXHAUSTED,
             )
 
         if on_event is not None:
@@ -185,17 +247,22 @@ async def run_tool_loop(
 
         # Stream the model response, assembling text + tool_calls from deltas
         try:
-            assistant_message, usage = await asyncio.wait_for(
-                _stream_and_assemble(client, messages, model, tools, on_token),
-                timeout=llm_timeout,
-            )
+            async with llm_semaphore or contextlib.nullcontext():
+                assistant_message, usage = await asyncio.wait_for(
+                    _stream_and_assemble(
+                        client, messages, model, tools, on_token,
+                        semaphore_held=llm_semaphore is not None,
+                    ),
+                    timeout=llm_timeout,
+                )
         except asyncio.TimeoutError:
             logger.error(
                 "Iteration %d: LLM stream timed out after %.0fs",
                 iteration, llm_timeout,
             )
-            return _maybe_with_usage(
-                f"LLM call timed out after {llm_timeout:.0f}s. Try again."
+            return _finish(
+                f"LLM call timed out after {llm_timeout:.0f}s. Try again.",
+                OUTCOME_LLM_TIMEOUT,
             )
 
         # Accumulate usage from this iteration
@@ -219,7 +286,7 @@ async def run_tool_loop(
         if not tool_calls:
             # No tool calls — streaming already emitted tokens; return the final text.
             content = assistant_message.get("content") or ""
-            return _maybe_with_usage(content)
+            return _finish(content, OUTCOME_OK)
 
         # Append the assistant message (with tool_calls) to the conversation
         messages.append(assistant_message)
@@ -288,11 +355,12 @@ async def run_tool_loop(
                 ))
 
             # Execute the tool with timeout, catching any exception
+            effective_timeout = TOOL_TIMEOUT_OVERRIDES.get(name, tool_timeout)
             t0 = time.monotonic()
             try:
                 result = await asyncio.wait_for(
                     tool_registry.execute(name, args, executor),
-                    timeout=tool_timeout,
+                    timeout=effective_timeout,
                 )
                 result_str = str(result) if not isinstance(result, str) else result
                 duration_ms = (time.monotonic() - t0) * 1000
@@ -303,7 +371,7 @@ async def run_tool_loop(
                 )
             except asyncio.TimeoutError:
                 duration_ms = (time.monotonic() - t0) * 1000
-                result_str = f"Error: tool {name} timed out after {tool_timeout:.0f}s"
+                result_str = f"Error: tool {name} timed out after {effective_timeout:.0f}s"
                 logger.error(
                     "Iteration %d: tool %s timed out after %.0fms",
                     iteration, name, duration_ms,
@@ -348,7 +416,7 @@ async def run_tool_loop(
         # After all tool calls in this batch, honour the deferred stop
         if stop_reply is not None:
             logger.info("Executing deferred turn stop")
-            return _maybe_with_usage(stop_reply)
+            return _finish(stop_reply, OUTCOME_OK)
 
     # Exhausted max_iterations — make one final call without tools to get a
     # text summary from the model, or return a fallback error.
@@ -363,11 +431,13 @@ async def run_tool_loop(
         if choices:
             content = choices[0]["message"].get("content", "")
             if content:
-                return _maybe_with_usage(content)
+                # The forced summary is a legitimate model reply.
+                return _finish(content, OUTCOME_OK)
     except Exception as exc:
         logger.error("Final call after max iterations failed: %s", exc)
 
-    return _maybe_with_usage(
+    return _finish(
         f"Reached the maximum of {max_iterations} tool iterations "
-        "without a final response."
+        "without a final response.",
+        OUTCOME_MAX_ITERATIONS,
     )

--- a/src/spare_paw/tools/browser.py
+++ b/src/spare_paw/tools/browser.py
@@ -26,7 +26,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SCREENSHOT_DIR = Path("/tmp/spare-paw-screenshots")
+SCREENSHOT_DIR = Path.home() / ".spare-paw" / "screenshots"
+_SCREENSHOT_MAX_AGE_DAYS = 7
+
+
+def _ensure_screenshot_dir() -> Path:
+    """Create the screenshot directory (owner-only permissions) and return it."""
+    SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    SCREENSHOT_DIR.chmod(0o700)
+    return SCREENSHOT_DIR
+
+
+def _cleanup_old_screenshots(max_age_days: int = _SCREENSHOT_MAX_AGE_DAYS) -> None:
+    """Delete screenshots older than *max_age_days* so they don't pile up."""
+    if not SCREENSHOT_DIR.is_dir():
+        return
+    cutoff = time.time() - max_age_days * 86400
+    for path in SCREENSHOT_DIR.glob("screenshot_*.png"):
+        try:
+            if path.stat().st_mtime < cutoff:
+                path.unlink()
+        except OSError:
+            logger.debug("Could not remove old screenshot: %s", path)
 
 
 # -- CDP Session -----------------------------------------------------------
@@ -47,6 +68,7 @@ class BrowserSession:
         self._recv_task: asyncio.Task | None = None
         self._ws_url: str | None = None
         self._chromium_cmd: str | None = None
+        self._connect_lock = asyncio.Lock()
 
     @classmethod
     def get(cls) -> BrowserSession:
@@ -56,8 +78,14 @@ class BrowserSession:
 
     async def ensure_connected(self) -> None:
         """Launch Chromium and connect if not already running."""
-        if self._ws is not None and not self._ws.closed:
-            return
+        async with self._connect_lock:
+            if self._ws is not None and not self._ws.closed:
+                return
+            await self._connect()
+
+    async def _connect(self) -> None:
+        """Spawn Chromium and establish the CDP connection (lock held by caller)."""
+        _cleanup_old_screenshots()
 
         # Find Chromium binary
         if self._chromium_cmd is None:
@@ -71,13 +99,7 @@ class BrowserSession:
                 )
 
         # Kill any stale process
-        if self._process is not None:
-            try:
-                self._process.terminate()
-                self._process.wait(timeout=5)
-            except Exception:
-                self._process.kill()
-            self._process = None
+        self._terminate_process()
 
         # Launch headless Chromium
         port = _find_free_port()
@@ -101,7 +123,12 @@ class BrowserSession:
 
         # Wait for DevTools to be ready
         cdp_base = f"http://127.0.0.1:{port}"
-        ws_url = await self._wait_for_devtools(cdp_base, timeout=15)
+        try:
+            ws_url = await self._wait_for_devtools(cdp_base, timeout=15)
+        except Exception:
+            # Don't leak the spawned process if DevTools never came up
+            self._terminate_process()
+            raise
         self._ws_url = ws_url
 
         # Connect WebSocket
@@ -135,6 +162,17 @@ class BrowserSession:
                 last_err = e
             await asyncio.sleep(0.5)
         raise RuntimeError(f"Chromium DevTools not ready after {timeout}s: {last_err}")
+
+    def _terminate_process(self) -> None:
+        """Terminate (or kill) the Chromium subprocess if one is running."""
+        if self._process is None:
+            return
+        try:
+            self._process.terminate()
+            self._process.wait(timeout=5)
+        except Exception:
+            self._process.kill()
+        self._process = None
 
     async def send(self, method: str, params: dict | None = None, timeout: float = 30) -> dict:
         """Send a CDP command and await the response."""
@@ -203,13 +241,7 @@ class BrowserSession:
             await self._http_session.close()
             self._http_session = None
 
-        if self._process is not None:
-            try:
-                self._process.terminate()
-                self._process.wait(timeout=5)
-            except Exception:
-                self._process.kill()
-            self._process = None
+        self._terminate_process()
 
         self._pending.clear()
         self._events.clear()
@@ -332,9 +364,9 @@ async def _handle_screenshot(full_page: bool = False) -> str:
         )
         data = base64.b64decode(result["data"])
 
-        SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+        shots_dir = _ensure_screenshot_dir()
         ts = int(time.time() * 1000)
-        path = SCREENSHOT_DIR / f"screenshot_{ts}.png"
+        path = shots_dir / f"screenshot_{ts}.png"
         path.write_bytes(data)
 
         return json.dumps({

--- a/src/spare_paw/tools/custom_tools.py
+++ b/src/spare_paw/tools/custom_tools.py
@@ -19,6 +19,8 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from spare_paw.util.redact import redact_secrets
+
 if TYPE_CHECKING:
     from spare_paw.tools.registry import ToolRegistry
 
@@ -26,6 +28,10 @@ logger = logging.getLogger(__name__)
 
 CUSTOM_TOOLS_DIR = Path.home() / ".spare-paw" / "custom_tools"
 PENDING_DIR = CUSTOM_TOOLS_DIR / ".pending"
+
+# Only these parent env vars are passed through to custom tool scripts.
+# Everything else (API keys, tokens from systemd EnvironmentFile, ...) is withheld.
+_ENV_ALLOWLIST = ("PATH", "HOME", "LANG", "LC_ALL", "TERM", "TMPDIR")
 
 # ---------------------------------------------------------------------------
 # Executor-compatible sync handler (top-level to avoid pickle errors)
@@ -44,15 +50,16 @@ def _execute_custom_tool(
     ``ProcessPoolExecutor``.  Parameters are passed to the script as
     environment variables.
     """
-    env = os.environ.copy()
+    env = {key: os.environ[key] for key in _ENV_ALLOWLIST if key in os.environ}
     for key, value in kwargs.items():
         env[f"TOOL_{key.upper()}"] = str(value)
 
+    params = ", ".join(f"{key}={value}" for key, value in kwargs.items())
     logger.info(
         "custom_tool: executing %s (timeout=%ds, params=%s)",
         script_path,
         timeout,
-        list(kwargs.keys()),
+        redact_secrets(params),
     )
 
     try:

--- a/src/spare_paw/tools/lcm_tools.py
+++ b/src/spare_paw/tools/lcm_tools.py
@@ -68,6 +68,18 @@ LCM_DESCRIBE_SCHEMA: dict[str, Any] = {
 # -- Handlers --------------------------------------------------------------
 
 
+def _parse_source_msg_ids(row: Any) -> list[str]:
+    """Parse a summary node's source_msg_ids JSON, defaulting to [] if corrupted."""
+    try:
+        return json.loads(row["source_msg_ids"])
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(
+            "Invalid JSON in summary_nodes.source_msg_ids for node %s — treating as empty",
+            row["id"],
+        )
+        return []
+
+
 async def _handle_lcm_grep(query: str, limit: int = 10) -> str:
     """Search both messages and summary_nodes via FTS5."""
     db = await get_db()
@@ -137,7 +149,7 @@ async def _handle_lcm_expand(summary_id: str, max_tokens: int = 4000) -> str:
     if node is None:
         return json.dumps({"error": f"Summary node not found: {summary_id}"})
 
-    source_msg_ids = json.loads(node["source_msg_ids"])
+    source_msg_ids = _parse_source_msg_ids(node)
     total_source_messages = len(source_msg_ids)
 
     if not source_msg_ids:
@@ -225,7 +237,7 @@ async def _handle_lcm_describe(
             "depth": row["depth"],
             "content": row["content"],
             "token_count": row["token_count"],
-            "source_msg_ids": json.loads(row["source_msg_ids"]),
+            "source_msg_ids": _parse_source_msg_ids(row),
             "created_at": row["created_at"],
         }
         for row in rows

--- a/src/spare_paw/tools/subagent.py
+++ b/src/spare_paw/tools/subagent.py
@@ -45,6 +45,24 @@ _agents: dict[str, dict[str, Any]] = {}
 _MAX_CONCURRENT = 10
 _MAX_PER_GROUP = 5  # max agents in a single group/batch
 
+# Groups whose completion callback has already been claimed (single-flight).
+_notified_groups: set[str] = set()
+
+# Set by shutdown(); distinguishes deliberate cancellation from watchdog kills.
+_shutting_down = False
+
+# Finished agents are kept in memory this long for list_agents, then reaped
+# (full history lives in the agents DB table).
+_AGENT_RETENTION_SECONDS = 3600
+
+
+def _config_int(config: Any, key: str, default: int) -> int:
+    """Read an int from config, falling back on missing/malformed values."""
+    try:
+        return int(config.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
 @dataclass
 class DialogueChannel:
     agent_id: str
@@ -266,14 +284,17 @@ AGENT_TYPES: dict[str, dict[str, Any]] = {
             "If the task is ambiguous or you need clarification, return status \"needs_info\" with your question."
             + _JSON_SCHEMA_INSTRUCTION
         ),
+        # Least privilege: researchers consume untrusted web content, so they
+        # get no shell/files access (prompt-injection → shell is the realistic
+        # attack chain for a web-facing agent).
         "tools": [
-            "tavily_search", "web_scrape", "shell", "files",
+            "tavily_search", "web_scrape",
             "browser_navigate", "browser_click", "browser_type",
             "browser_screenshot", "browser_get_text", "browser_eval_js",
             "browser_get_elements", "browser_wait", "browser_select",
             "browser_scroll", "browser_back",
         ],
-        "tool_limits": {"web_search": 10, "tavily_search": 10, "shell": 10, "browser_navigate": 10},
+        "tool_limits": {"web_search": 10, "tavily_search": 10, "browser_navigate": 10},
     },
     "coder": {
         "system_suffix": (
@@ -305,28 +326,115 @@ AGENT_TYPES: dict[str, dict[str, Any]] = {
             "If a page requires login or hits a CAPTCHA, return status \"needs_info\"."
             + _JSON_SCHEMA_INSTRUCTION
         ),
+        # Least privilege: browser agents consume untrusted web content — no
+        # shell/files access (see researcher note above).
         "tools": [
             "browser_navigate", "browser_click", "browser_type",
             "browser_screenshot", "browser_get_text", "browser_eval_js",
             "browser_get_elements", "browser_wait", "browser_select",
             "browser_scroll", "browser_back",
-            "files", "shell",
         ],
-        "tool_limits": {"browser_navigate": 15, "browser_click": 30, "browser_type": 20, "shell": 10},
+        "tool_limits": {"browser_navigate": 15, "browser_click": 30, "browser_type": 20},
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# Durable state (best-effort — never lets persistence break the agent flow)
+# ---------------------------------------------------------------------------
+
+async def _persist_agent(agent_id: str) -> None:
+    """Upsert the agent's current state into the agents table."""
+    info = _agents.get(agent_id)
+    if info is None:
+        return
+    try:
+        from spare_paw.db import get_db, is_initialized
+        if not is_initialized():
+            return
+        db = await get_db()
+        usage = info.get("usage")
+        await db.execute(
+            """
+            INSERT INTO agents
+                (id, name, group_id, agent_type, status, prompt, result,
+                 error, usage, created_at, finished_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                status = excluded.status,
+                result = excluded.result,
+                error = excluded.error,
+                usage = excluded.usage,
+                finished_at = excluded.finished_at
+            """,
+            (
+                agent_id,
+                info.get("name"),
+                info.get("group_id"),
+                info.get("agent_type"),
+                info.get("status", "unknown"),
+                info.get("prompt"),
+                info.get("result"),
+                info.get("error"),
+                json.dumps(usage) if usage else None,
+                info.get("created_at"),
+                info.get("finished_at"),
+            ),
+        )
+        await db.commit()
+    except Exception:
+        logger.exception("Failed to persist agent %s", agent_id[:8])
+
+
+async def _persist_callback(group_id: str, payload: str) -> int | None:
+    """Write a pending callback row; returns its id (or None on failure)."""
+    try:
+        from spare_paw.db import get_db, is_initialized
+        if not is_initialized():
+            return None
+        db = await get_db()
+        cur = await db.execute(
+            "INSERT INTO agent_callbacks (group_id, payload, delivered, created_at) "
+            "VALUES (?, ?, 0, ?)",
+            (group_id, payload, datetime.now(timezone.utc).isoformat()),
+        )
+        await db.commit()
+        return cur.lastrowid
+    except Exception:
+        logger.exception("Failed to persist callback for group %s", group_id)
+        return None
 
 
 # ---------------------------------------------------------------------------
 # Group completion check
 # ---------------------------------------------------------------------------
 
+_TERMINAL_STATUSES = ("completed", "failed", "timed_out", "interrupted")
+
+
 def _check_group_complete(group_id: str) -> bool:
     """Return True if all agents in the group have finished (completed or failed)."""
     group = [a for a in _agents.values() if a.get("group_id") == group_id]
     if not group:
         return False
-    return all(a["status"] in ("completed", "failed", "timed_out") for a in group)
+    return all(a["status"] in _TERMINAL_STATUSES for a in group)
+
+
+async def _maybe_notify_group(group_id: str) -> None:
+    """Notify the main agent once per group, no matter how many finishers race.
+
+    The claim is taken synchronously (no await between check and add), so two
+    agents finishing in the same event-loop tick cannot both pass it.
+    """
+    if not _check_group_complete(group_id):
+        return
+    if group_id in _notified_groups:
+        return
+    _notified_groups.add(group_id)
+    try:
+        await _notify_main_agent(group_id)
+    except Exception:
+        logger.exception("Failed to notify main agent for group %s", group_id)
 
 
 async def _notify_main_agent(group_id: str) -> None:
@@ -392,9 +500,21 @@ async def _notify_main_agent(group_id: str) -> None:
                 if msg_id is not None:
                     await backend.delete_progress(msg_id)
 
+    # Persist first: if the process dies (or the queue is gone) before the
+    # callback is processed, startup recovery re-enqueues undelivered rows.
+    callback_id = await _persist_callback(group_id, synthetic_text)
+
     if _message_queue is not None:
-        await _message_queue.put(("agent_callback", synthetic_text))
+        if callback_id is not None:
+            await _message_queue.put(("agent_callback", synthetic_text, callback_id))
+        else:
+            await _message_queue.put(("agent_callback", synthetic_text))
         logger.info("Group %s: pushed callback with %d agent results", group_id, len(group))
+    elif callback_id is not None:
+        logger.warning(
+            "Group %s completed with no message queue — callback %d persisted "
+            "for recovery on next startup", group_id, callback_id,
+        )
     else:
         logger.error("Group %s completed but no message queue — results DROPPED", group_id)
 
@@ -406,20 +526,24 @@ def _on_agent_done(agent_id: str, task: asyncio.Task) -> None:
     exc = task.exception()
     if exc is None:
         return  # Normal completion — _run_agent already updated status
+    info = _agents.get(agent_id)
+    if info is None:
+        logger.error("Agent %s crashed after eviction: %s", agent_id[:8], exc)
+        return
     error_msg = f"{type(exc).__name__}: {exc}"
-    _agents[agent_id]["status"] = "failed"
-    _agents[agent_id]["error"] = error_msg
-    _agents[agent_id].setdefault(
-        "finished_at", datetime.now(timezone.utc).isoformat()
-    )
+    info["status"] = "failed"
+    info["error"] = error_msg
+    info.setdefault("finished_at", datetime.now(timezone.utc).isoformat())
     logger.error("Agent %s crashed (done-callback): %s", agent_id[:8], error_msg)
 
     _cleanup_channel(agent_id)
 
-    group_id = _agents[agent_id].get("group_id")
-    if group_id and _check_group_complete(group_id):
+    asyncio.create_task(_persist_agent(agent_id), name=f"agent-persist-{agent_id}")
+
+    group_id = info.get("group_id")
+    if group_id:
         asyncio.create_task(
-            _notify_main_agent(group_id),
+            _maybe_notify_group(group_id),
             name=f"agent-notify-{group_id}",
         )
 
@@ -429,10 +553,30 @@ def _on_agent_done(agent_id: str, task: asyncio.Task) -> None:
 # ---------------------------------------------------------------------------
 
 async def _watchdog_tick() -> None:
-    """Single pass: cancel any stuck agents."""
+    """Single pass: cancel any stuck agents, reap old finished ones."""
     now = datetime.now(timezone.utc)
     for agent_id, info in list(_agents.items()):
-        if info["status"] != "running":
+        status = info["status"]
+
+        # Reap finished agents after the retention window — their full record
+        # is in the agents DB table; keeping them in memory forever leaks.
+        if status in _TERMINAL_STATUSES:
+            finished_at = info.get("finished_at")
+            if finished_at:
+                try:
+                    finished = datetime.fromisoformat(finished_at)
+                except ValueError:
+                    continue
+                if (now - finished).total_seconds() > _AGENT_RETENTION_SECONDS:
+                    group_id = info.get("group_id")
+                    _agents.pop(agent_id, None)
+                    if group_id and not any(
+                        a.get("group_id") == group_id for a in _agents.values()
+                    ):
+                        _notified_groups.discard(group_id)
+            continue
+
+        if status != "running":
             continue
         last = info.get("last_activity")
         if last is None:
@@ -465,6 +609,35 @@ def start_watchdog() -> None:
         _watchdog_task = asyncio.create_task(_watchdog_loop(), name="agent-watchdog")
 
 
+async def shutdown(timeout: float = 5.0) -> None:
+    """Orderly teardown: stop the watchdog, cancel running agents, wait briefly.
+
+    Cancelled agents record status "interrupted" (persisted via _run_agent's
+    finally block) so startup recovery can tell the user what was lost.
+    """
+    global _shutting_down
+    _shutting_down = True
+
+    if _watchdog_task is not None and not _watchdog_task.done():
+        _watchdog_task.cancel()
+
+    tasks = [
+        info["task"]
+        for info in _agents.values()
+        if info.get("task") is not None and not info["task"].done()
+    ]
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        done, pending = await asyncio.wait(tasks, timeout=timeout)
+        if pending:
+            logger.warning(
+                "%d agent task(s) did not finish within %.0fs of shutdown",
+                len(pending), timeout,
+            )
+    logger.info("Subagent shutdown complete (%d agents cancelled)", len(tasks))
+
+
 # ---------------------------------------------------------------------------
 # Agent execution
 # ---------------------------------------------------------------------------
@@ -485,7 +658,7 @@ async def _run_agent(
 
     try:
         from spare_paw.core.prompt import build_subagent_prompt
-        from spare_paw.router.tool_loop import run_tool_loop
+        from spare_paw.router.tool_loop import coerce_loop_result, run_tool_loop
 
         # Build lightweight system prompt for subagent
         system_prompt = await build_subagent_prompt(suffix=system_suffix)
@@ -552,8 +725,11 @@ async def _run_agent(
         def _heartbeat(event: Any) -> None:
             _agents[agent_id]["last_activity"] = datetime.now(timezone.utc)
 
-        # Run tool loop with usage tracking
-        result_text, usage = await run_tool_loop(
+        # Hard cost ceiling for the whole agent run
+        token_budget = _config_int(app_state.config, "agent.subagent_token_budget", 150000)
+
+        # Run tool loop with structured outcome + usage tracking
+        loop_result = coerce_loop_result(await run_tool_loop(
             client=app_state.router_client,
             messages=messages,
             model=resolved_model,
@@ -561,23 +737,39 @@ async def _run_agent(
             tool_registry=agent_registry,
             max_iterations=max_iterations,
             executor=app_state.executor,
-            track_usage=True,
+            return_result=True,
+            token_budget=token_budget,
             tool_limits=tool_limits,
             on_event=_heartbeat,
-        )
-
-        parsed = parse_agent_result(result_text)
-        _agents[agent_id]["status"] = "completed"
+        ))
+        result_text = loop_result.text
         _agents[agent_id]["result"] = result_text
-        _agents[agent_id]["parsed_result"] = parsed
-        _agents[agent_id]["result_preview"] = parsed["summary"]
-        _agents[agent_id]["usage"] = usage
-        logger.info("Agent %s completed (agent_status=%s)", agent_id[:8], parsed["status"])
+        _agents[agent_id]["usage"] = loop_result.usage
+
+        if not loop_result.ok:
+            # Loop-level failure (timeout, budget, iteration cap) — never
+            # report it as a completed agent with the error text as findings.
+            _agents[agent_id]["status"] = "failed"
+            _agents[agent_id]["error"] = f"{loop_result.outcome}: {result_text[:200]}"
+            logger.warning(
+                "Agent %s failed (loop outcome=%s)", agent_id[:8], loop_result.outcome,
+            )
+        else:
+            parsed = parse_agent_result(result_text)
+            _agents[agent_id]["status"] = "completed"
+            _agents[agent_id]["parsed_result"] = parsed
+            _agents[agent_id]["result_preview"] = parsed["summary"]
+            logger.info("Agent %s completed (agent_status=%s)", agent_id[:8], parsed["status"])
 
     except asyncio.CancelledError:
-        _agents[agent_id]["status"] = "timed_out"
-        _agents[agent_id]["error"] = "Agent timed out: no activity for too long"
-        logger.warning("Agent %s timed out (cancelled by watchdog)", agent_id[:8])
+        if _shutting_down:
+            _agents[agent_id]["status"] = "interrupted"
+            _agents[agent_id]["error"] = "Interrupted by shutdown/restart"
+            logger.info("Agent %s interrupted by shutdown", agent_id[:8])
+        else:
+            _agents[agent_id]["status"] = "timed_out"
+            _agents[agent_id]["error"] = "Agent timed out: no activity for too long"
+            logger.warning("Agent %s timed out (cancelled by watchdog)", agent_id[:8])
 
     except Exception as exc:
         error_msg = f"{type(exc).__name__}: {exc}"
@@ -598,7 +790,7 @@ async def _run_agent(
                 group_id = _agents[agent_id].get("group_id")
                 if group_id:
                     group = [a for a in _agents.values() if a.get("group_id") == group_id]
-                    done = sum(1 for a in group if a["status"] in ("completed", "failed", "timed_out"))
+                    done = sum(1 for a in group if a["status"] in _TERMINAL_STATUSES)
                     total = len(group)
                     status_emoji = "\u2705" if _agents[agent_id]["status"] == "completed" else "\u274c"
                     try:
@@ -609,13 +801,12 @@ async def _run_agent(
                     except Exception:
                         pass
 
-        # Check if the group is complete and notify
+        # Persist the terminal state, then check if the group is complete
+        await _persist_agent(agent_id)
+
         group_id = _agents[agent_id].get("group_id")
-        if group_id and _check_group_complete(group_id):
-            try:
-                await _notify_main_agent(group_id)
-            except Exception:
-                logger.exception("Failed to notify main agent for group %s", group_id)
+        if group_id:
+            await _maybe_notify_group(group_id)
 
 
 async def _handle_spawn(
@@ -645,6 +836,10 @@ async def _handle_spawn(
                 "status": "group_full",
                 "message": f"Max {_MAX_PER_GROUP} agents per group. Do NOT spawn more — reply to the user now.",
             })
+
+    # Clamp iterations server-side regardless of what the model asked for
+    cap = _config_int(app_state.config, "agent.subagent_max_iterations_cap", 30)
+    max_iterations = max(1, min(max_iterations, cap))
 
     # Resolve agent type
     tools_filter = tools
@@ -697,11 +892,18 @@ async def _handle_spawn(
     _agents[agent_id]["task"] = task
     task.add_done_callback(lambda t, aid=agent_id: _on_agent_done(aid, t))
 
-    # Send ephemeral progress message (Telegram-specific)
+    await _persist_agent(agent_id)
+
+    # Send ephemeral progress message (Telegram-specific). A delivery failure
+    # must not fail the spawn \u2014 the agent task is already running, and a tool
+    # error here would prompt the model to spawn a duplicate.
     backend = getattr(app_state, "backend", None)
     if backend is not None and hasattr(type(backend), "send_progress"):
-        msg_id = await backend.send_progress(f"\u23f3 Working on: {name}...")
-        _agents[agent_id]["progress_message_id"] = msg_id
+        try:
+            msg_id = await backend.send_progress(f"\u23f3 Working on: {name}...")
+            _agents[agent_id]["progress_message_id"] = msg_id
+        except Exception:
+            logger.exception("Failed to send progress message for agent %s", agent_id)
 
     logger.info("Spawned agent %s: %s (group=%s)", agent_id, name, resolved_group_id)
     return json.dumps({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,21 @@
 from __future__ import annotations
 
 import os
+import sys
+
+import pytest
 
 
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_sessionfinish(session, exitstatus):
-    """Force-kill any lingering APScheduler threads after all tests complete."""
+    """Force-kill any lingering APScheduler threads after all tests complete.
+
+    Implemented as a tryfirst hookwrapper so the exit happens strictly AFTER
+    the terminal reporter (also a wrapper) has printed its summary, and the
+    flushes ensure output survives os._exit (which skips interpreter cleanup —
+    without them the report is lost whenever stdout is a pipe).
+    """
+    yield
+    sys.stdout.flush()
+    sys.stderr.flush()
     os._exit(exitstatus)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
-from unittest.mock import AsyncMock, patch
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -59,6 +63,122 @@ class TestBrowserSession:
         await session.close()
         assert session._pending == {}
         assert session._events == {}
+
+
+# -- Session lifecycle -------------------------------------------------------
+
+
+class TestSessionLifecycle:
+    def _patch_launch(self, monkeypatch, tmp_path) -> MagicMock:
+        """Stub out everything around Chromium spawning; returns the Popen mock."""
+        monkeypatch.setattr("spare_paw.tools.browser.SCREENSHOT_DIR", tmp_path)
+        monkeypatch.setattr(
+            "spare_paw.tools.browser.shutil.which", lambda cmd: "/usr/bin/chromium"
+        )
+        monkeypatch.setattr("spare_paw.tools.browser._find_free_port", lambda: 9222)
+        popen_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("spare_paw.tools.browser.subprocess.Popen", popen_mock)
+        return popen_mock
+
+    @pytest.mark.asyncio
+    async def test_devtools_timeout_terminates_spawned_process(self, monkeypatch, tmp_path):
+        popen_mock = self._patch_launch(monkeypatch, tmp_path)
+        fake_proc = popen_mock.return_value
+
+        async def _never_ready(self, cdp_base, timeout):
+            raise RuntimeError("Chromium DevTools not ready after 15s")
+
+        monkeypatch.setattr(BrowserSession, "_wait_for_devtools", _never_ready)
+
+        session = BrowserSession()
+        with pytest.raises(RuntimeError):
+            await session.ensure_connected()
+
+        assert fake_proc.terminate.called or fake_proc.kill.called, (
+            "spawned Chromium process must be cleaned up when DevTools never comes up"
+        )
+        assert session._process is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_ensure_connected_spawns_once(self, monkeypatch, tmp_path):
+        popen_mock = self._patch_launch(monkeypatch, tmp_path)
+
+        # An old screenshot that session start should clean up (fix 5)
+        stale = tmp_path / "screenshot_1.png"
+        stale.write_bytes(b"old")
+        eight_days_ago = time.time() - 8 * 86400
+        os.utime(stale, (eight_days_ago, eight_days_ago))
+
+        async def _slow_ready(self, cdp_base, timeout):
+            await asyncio.sleep(0.05)
+            return "ws://127.0.0.1:9222/devtools/page/1"
+
+        monkeypatch.setattr(BrowserSession, "_wait_for_devtools", _slow_ready)
+        monkeypatch.setattr(BrowserSession, "_recv_loop", AsyncMock())
+
+        session = BrowserSession()
+        fake_ws = MagicMock()
+        fake_ws.closed = False
+        http_session = MagicMock()
+        http_session.closed = False
+        http_session.ws_connect = AsyncMock(return_value=fake_ws)
+        session._http_session = http_session
+        monkeypatch.setattr(session, "send", AsyncMock(return_value={}))
+
+        await asyncio.gather(session.ensure_connected(), session.ensure_connected())
+
+        assert popen_mock.call_count == 1, "concurrent connects must not spawn twice"
+        assert not stale.exists(), "old screenshots should be cleaned on session start"
+
+
+# -- Screenshot directory ----------------------------------------------------
+
+
+class TestScreenshotDir:
+    def test_default_dir_is_private_home_location(self):
+        from spare_paw.tools import browser
+
+        assert str(browser.SCREENSHOT_DIR).startswith(str(Path.home()))
+        assert not str(browser.SCREENSHOT_DIR).startswith("/tmp")
+
+    def test_cleanup_removes_only_old_screenshots(self, tmp_path, monkeypatch):
+        from spare_paw.tools.browser import _cleanup_old_screenshots
+
+        monkeypatch.setattr("spare_paw.tools.browser.SCREENSHOT_DIR", tmp_path)
+        old = tmp_path / "screenshot_100.png"
+        old.write_bytes(b"old")
+        eight_days_ago = time.time() - 8 * 86400
+        os.utime(old, (eight_days_ago, eight_days_ago))
+        fresh = tmp_path / "screenshot_200.png"
+        fresh.write_bytes(b"new")
+
+        _cleanup_old_screenshots()
+
+        assert not old.exists()
+        assert fresh.exists()
+
+    def test_cleanup_missing_dir_is_noop(self, tmp_path, monkeypatch):
+        from spare_paw.tools.browser import _cleanup_old_screenshots
+
+        monkeypatch.setattr("spare_paw.tools.browser.SCREENSHOT_DIR", tmp_path / "missing")
+        _cleanup_old_screenshots()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_screenshot_dir_created_with_0700(self, tmp_path, monkeypatch):
+        import base64
+
+        target = tmp_path / "shots"
+        monkeypatch.setattr("spare_paw.tools.browser.SCREENSHOT_DIR", target)
+        mock_session = _make_session_mock()
+        mock_session.send.return_value = {
+            "data": base64.b64encode(b"\x89PNG\r\n\x1a\n").decode()
+        }
+
+        with patch("spare_paw.tools.browser._ensure_session", return_value=mock_session):
+            result = json.loads(await _handle_screenshot())
+
+        assert "path" in result
+        assert (target.stat().st_mode & 0o777) == 0o700
 
 
 # -- Navigate --------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 from pathlib import Path
 
+import pytest
 import yaml
 
 from spare_paw.config import (
@@ -114,6 +115,24 @@ class TestConfigLoad:
         cfg = Config()
         cfg.load(cfg_file)
         assert cfg.get("agent.max_tool_iterations") == DEFAULTS["agent"]["max_tool_iterations"]
+
+    def test_load_malformed_yaml_raises_clear_error(self, tmp_path: Path):
+        """Malformed YAML must fail fast with a RuntimeError naming the file."""
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("logging: [unclosed\n")
+        cfg = Config()
+        with pytest.raises(RuntimeError) as excinfo:
+            cfg.load(cfg_file)
+        assert str(cfg_file) in str(excinfo.value)
+
+    def test_load_non_dict_yaml_raises_clear_error(self, tmp_path: Path):
+        """A YAML file that parses to a non-dict must fail fast with a clear error."""
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("just a bare string\n")
+        cfg = Config()
+        with pytest.raises(RuntimeError) as excinfo:
+            cfg.load(cfg_file)
+        assert str(cfg_file) in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 import pytest_asyncio
 import aiosqlite
@@ -151,6 +153,32 @@ async def test_assemble_caps_summary_tokens(_init_db, monkeypatch):
     assert "Summary 9" in last_summary, "Newest summary should be included"
 
     config_mod.config.set_override("context.summary_token_budget", 5000)
+
+
+@pytest.mark.asyncio
+async def test_assemble_skips_corrupt_metadata(_init_db):
+    """A message row with corrupt JSON in the metadata column must not crash assemble()."""
+    conn = _init_db
+    conv_id = await new_conversation()
+    await ingest(conv_id, "user", "Hello")
+
+    # Insert a message with garbage in the metadata column directly
+    await conn.execute(
+        """INSERT INTO messages (id, conversation_id, role, content, token_count, created_at, metadata)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        ("corrupt-meta-msg", conv_id, "assistant", "I did something", 5,
+         datetime.now(timezone.utc).isoformat(), "{not valid json"),
+    )
+    await conn.commit()
+
+    messages = await assemble(conv_id, "sys")
+
+    # The corrupt row is still included — only its metadata is skipped
+    contents = [m["content"] for m in messages]
+    assert "I did something" in contents
+    corrupt = next(m for m in messages if m["content"] == "I did something")
+    assert "tool_call_id" not in corrupt
+    assert "tool_calls" not in corrupt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -38,7 +38,7 @@ def _make_app_state(**overrides) -> MagicMock:
 # CronScheduler CRUD
 # ---------------------------------------------------------------------------
 
-def _make_scheduler() -> CronScheduler:
+def _make_scheduler(job_defaults: dict | None = None) -> CronScheduler:
     """Create a CronScheduler with a real AsyncIOScheduler started in paused mode.
 
     Must be called from within a running event loop (i.e. inside an async test).
@@ -46,7 +46,10 @@ def _make_scheduler() -> CronScheduler:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
     sched = CronScheduler(MagicMock())
-    sched._scheduler = AsyncIOScheduler()
+    if job_defaults is not None:
+        sched._scheduler = AsyncIOScheduler(job_defaults=job_defaults)
+    else:
+        sched._scheduler = AsyncIOScheduler()
     sched._scheduler.start(paused=True)
     return sched
 
@@ -129,6 +132,134 @@ class TestCronSchedulerCRUD:
 
 
 # ---------------------------------------------------------------------------
+# Missed-job semantics and overlap prevention
+# ---------------------------------------------------------------------------
+
+
+class TestCronJobRobustness:
+    """Jobs must carry explicit misfire/coalesce/max_instances settings.
+
+    Settings must be set per-job rather than inherited from whatever the
+    scheduler's job_defaults happen to be — so a job missed while the
+    process was down runs once on restart, and slow runs can't overlap.
+    """
+
+    @pytest.mark.asyncio
+    async def test_add_job_sets_explicit_misfire_settings(self):
+        # Hostile job_defaults: if add_job relies on scheduler defaults,
+        # these leak through and the assertions below fail.
+        scheduler = _make_scheduler(
+            job_defaults={"misfire_grace_time": 30, "coalesce": False, "max_instances": 3}
+        )
+        try:
+            await scheduler.add_job("job-robust", "*/5 * * * *", "do something")
+            job = scheduler._scheduler.get_job("job-robust")
+            assert job.misfire_grace_time == 3600
+            assert job.coalesce is True
+            assert job.max_instances == 1
+        finally:
+            scheduler._scheduler.shutdown(wait=False)
+
+    @pytest.mark.asyncio
+    async def test_start_schedules_db_jobs_with_explicit_misfire_settings(self):
+        rows = [
+            {
+                "id": "db-job-1",
+                "schedule": "59 23 31 12 *",
+                "prompt": "yearly task",
+                "model": None,
+                "tools_allowed": None,
+            }
+        ]
+        mock_cursor = AsyncMock()
+        mock_cursor.fetchall = AsyncMock(return_value=rows)
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_db = MagicMock()
+        mock_db.execute = MagicMock(return_value=mock_ctx)
+
+        scheduler = CronScheduler(_make_app_state())
+        with patch("spare_paw.cron.scheduler.get_db", AsyncMock(return_value=mock_db)):
+            await scheduler.start()
+        try:
+            job = scheduler._scheduler.get_job("db-job-1")
+            assert job is not None
+            assert job.misfire_grace_time == 3600
+            assert job.coalesce is True
+            assert job.max_instances == 1
+        finally:
+            await scheduler.stop()
+
+
+# ---------------------------------------------------------------------------
+# Explicit timezone
+# ---------------------------------------------------------------------------
+
+
+def _app_state_with_tz(tz_name: str) -> MagicMock:
+    """Mock AppState whose config returns tz_name for cron.timezone."""
+    app_state = _make_app_state()
+    orig = app_state.config.get.side_effect
+    app_state.config.get = MagicMock(
+        side_effect=lambda key, default=None: (
+            tz_name if key == "cron.timezone" else orig(key, default)
+        )
+    )
+    return app_state
+
+
+class TestCronTimezone:
+    """CronTrigger must be built with an explicit timezone."""
+
+    @pytest.mark.asyncio
+    async def test_add_job_uses_configured_timezone(self):
+        from zoneinfo import ZoneInfo
+
+        from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+        sched = CronScheduler(_app_state_with_tz("Pacific/Kiritimati"))
+        sched._scheduler = AsyncIOScheduler()
+        sched._scheduler.start(paused=True)
+        try:
+            await sched.add_job("job-tz", "0 9 * * *", "morning task")
+            job = sched._scheduler.get_job("job-tz")
+            assert job.trigger.timezone == ZoneInfo("Pacific/Kiritimati")
+        finally:
+            sched._scheduler.shutdown(wait=False)
+
+    @pytest.mark.asyncio
+    async def test_add_job_falls_back_to_explicit_system_local_timezone(self):
+        from datetime import datetime
+
+        from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+        sched = CronScheduler(_make_app_state())  # no cron.timezone configured
+        sched._scheduler = AsyncIOScheduler()
+        sched._scheduler.start(paused=True)
+        try:
+            await sched.add_job("job-tz-local", "0 9 * * *", "morning task")
+            job = sched._scheduler.get_job("job-tz-local")
+            assert job.trigger.timezone == datetime.now().astimezone().tzinfo
+        finally:
+            sched._scheduler.shutdown(wait=False)
+
+    @pytest.mark.asyncio
+    async def test_invalid_timezone_falls_back_to_local(self):
+        from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+        sched = CronScheduler(_app_state_with_tz("Not/AZone"))
+        sched._scheduler = AsyncIOScheduler()
+        sched._scheduler.start(paused=True)
+        try:
+            await sched.add_job("job-tz-bad", "0 9 * * *", "morning task")
+            job = sched._scheduler.get_job("job-tz-bad")
+            assert job is not None  # bad config must not break scheduling
+        finally:
+            sched._scheduler.shutdown(wait=False)
+
+
+# ---------------------------------------------------------------------------
 # execute_cron — success path
 # ---------------------------------------------------------------------------
 
@@ -136,10 +267,14 @@ class TestExecuteCronSuccess:
     """Test execute_cron sends the result to Telegram on success."""
 
     @pytest.mark.asyncio
-    @patch("spare_paw.cron.executor._maybe_delete_once", new_callable=AsyncMock)
+    @patch(
+        "spare_paw.cron.executor._claim_one_shot",
+        new_callable=AsyncMock,
+        return_value=(False, {}),
+    )
     @patch("spare_paw.cron.executor._update_cron_result", new_callable=AsyncMock)
     @patch("spare_paw.cron.executor.run_tool_loop", new_callable=AsyncMock)
-    async def test_sends_result_to_telegram(self, mock_tool_loop, mock_update, _mock_delete):
+    async def test_sends_result_to_telegram(self, mock_tool_loop, mock_update, _mock_claim):
         from spare_paw.cron.executor import execute_cron
 
         mock_tool_loop.return_value = "Cron result text"
@@ -171,10 +306,14 @@ class TestExecuteCronError:
     """Test execute_cron handles errors and sends warning message."""
 
     @pytest.mark.asyncio
-    @patch("spare_paw.cron.executor._maybe_delete_once", new_callable=AsyncMock)
+    @patch(
+        "spare_paw.cron.executor._claim_one_shot",
+        new_callable=AsyncMock,
+        return_value=(False, {}),
+    )
     @patch("spare_paw.cron.executor._update_cron_result", new_callable=AsyncMock)
     @patch("spare_paw.cron.executor.run_tool_loop", new_callable=AsyncMock)
-    async def test_sends_warning_on_failure(self, mock_tool_loop, mock_update, _mock_delete):
+    async def test_sends_warning_on_failure(self, mock_tool_loop, mock_update, _mock_claim):
         from spare_paw.cron.executor import execute_cron
 
         mock_tool_loop.side_effect = RuntimeError("model exploded")
@@ -198,10 +337,14 @@ class TestExecuteCronError:
         )
 
     @pytest.mark.asyncio
-    @patch("spare_paw.cron.executor._maybe_delete_once", new_callable=AsyncMock)
+    @patch(
+        "spare_paw.cron.executor._claim_one_shot",
+        new_callable=AsyncMock,
+        return_value=(False, {}),
+    )
     @patch("spare_paw.cron.executor._update_cron_result", new_callable=AsyncMock)
     @patch("spare_paw.cron.executor.run_tool_loop", new_callable=AsyncMock)
-    async def test_error_notification_failure_does_not_propagate(self, mock_tool_loop, mock_update, _mock_delete):  # noqa: E501
+    async def test_error_notification_failure_does_not_propagate(self, mock_tool_loop, mock_update, _mock_claim):  # noqa: E501
         """If sending the error notification itself fails, execute_cron still doesn't raise."""
         from spare_paw.cron.executor import execute_cron
 
@@ -220,35 +363,40 @@ class TestExecuteCronError:
 
 
 # ---------------------------------------------------------------------------
-# One-shot auto-delete
+# One-shot crash safety (claim-then-run)
 # ---------------------------------------------------------------------------
 
 
-class TestOneShotCronAutoDelete:
-    """Test _maybe_delete_once auto-deletes crons with metadata.once=true."""
+def _make_mock_db(row, rowcount: int = 1, events: list[str] | None = None) -> MagicMock:
+    """Mock aiosqlite DB: fetchone returns `row`; DELETEs are recorded in `events`."""
+    mock_cursor = AsyncMock()
+    mock_cursor.fetchone = AsyncMock(return_value=row)
+    mock_cursor.rowcount = rowcount
+
+    async def _execute(sql, *args, **kwargs):
+        if events is not None and "DELETE" in sql:
+            events.append("delete")
+        return mock_cursor
+
+    mock_db = MagicMock()
+    mock_db.execute = AsyncMock(side_effect=_execute)
+    mock_db.commit = AsyncMock()
+    return mock_db
+
+
+class TestClaimOneShot:
+    """_claim_one_shot consumes the row of once=true crons before execution."""
 
     @pytest.mark.asyncio
-    async def test_one_shot_cron_auto_deletes(self):
-        """A cron with metadata={"once": true} should be deleted after execution."""
-        from spare_paw.cron.executor import _maybe_delete_once
+    async def test_claims_and_deletes_once_cron(self):
+        from spare_paw.cron.executor import _claim_one_shot
 
-        # Build a mock DB that returns a row with once=true metadata
-        mock_row = {"metadata": '{"once": true}'}
-        mock_cursor = AsyncMock()
-        mock_cursor.fetchone = AsyncMock(return_value=mock_row)
+        mock_db = _make_mock_db({"metadata": '{"once": true}'})
+        with patch("spare_paw.cron.executor.get_db", AsyncMock(return_value=mock_db)):
+            once, metadata = await _claim_one_shot("cron-once-1")
 
-        mock_db = AsyncMock()
-        mock_db.execute = AsyncMock(return_value=mock_cursor)
-        mock_db.commit = AsyncMock()
-
-        app_state = _make_app_state()
-        app_state.scheduler = AsyncMock()
-        app_state.scheduler.remove_job = AsyncMock()
-
-        with patch("spare_paw.cron.executor.get_db", return_value=mock_db):
-            await _maybe_delete_once(app_state, "cron-once-1")
-
-        # Verify DELETE was issued
+        assert once is True
+        assert metadata == {"once": True}
         delete_calls = [
             call for call in mock_db.execute.call_args_list
             if "DELETE" in str(call)
@@ -256,27 +404,119 @@ class TestOneShotCronAutoDelete:
         assert len(delete_calls) == 1
         assert "cron-once-1" in str(delete_calls[0])
 
-        # Verify scheduler was notified
-        app_state.scheduler.remove_job.assert_awaited_once_with("cron-once-1")
-
     @pytest.mark.asyncio
     async def test_non_once_cron_is_not_deleted(self):
         """A cron without once=true in metadata should NOT be deleted."""
-        from spare_paw.cron.executor import _maybe_delete_once
+        from spare_paw.cron.executor import _claim_one_shot
 
-        mock_row = {"metadata": '{"repeat": true}'}
-        mock_cursor = AsyncMock()
-        mock_cursor.fetchone = AsyncMock(return_value=mock_row)
+        mock_db = _make_mock_db({"metadata": '{"repeat": true}'})
+        with patch("spare_paw.cron.executor.get_db", AsyncMock(return_value=mock_db)):
+            once, metadata = await _claim_one_shot("cron-repeat")
 
-        mock_db = AsyncMock()
-        mock_db.execute = AsyncMock(return_value=mock_cursor)
+        assert once is False
+        assert metadata == {"repeat": True}
+        assert "DELETE" not in str(mock_db.execute.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_missing_row_reports_already_claimed(self):
+        from spare_paw.cron.executor import _claim_one_shot
+
+        mock_db = _make_mock_db(None)
+        with patch("spare_paw.cron.executor.get_db", AsyncMock(return_value=mock_db)):
+            once, _metadata = await _claim_one_shot("cron-gone")
+
+        assert once is None
+
+    @pytest.mark.asyncio
+    async def test_lost_delete_race_reports_already_claimed(self):
+        """If the DELETE claims no row, another run already consumed the cron."""
+        from spare_paw.cron.executor import _claim_one_shot
+
+        mock_db = _make_mock_db({"metadata": '{"once": true}'}, rowcount=0)
+        with patch("spare_paw.cron.executor.get_db", AsyncMock(return_value=mock_db)):
+            once, _metadata = await _claim_one_shot("cron-raced")
+
+        assert once is None
+
+
+class TestOneShotClaimThenRun:
+    """One-shot crons are consumed from the DB BEFORE their work executes.
+
+    Deleting the row after execution means a crash after the work (or a
+    restart mid-run) fires the job twice; claiming first makes that impossible.
+    """
+
+    @pytest.mark.asyncio
+    @patch("spare_paw.cron.executor._update_cron_result", new_callable=AsyncMock)
+    @patch("spare_paw.cron.executor.run_tool_loop", new_callable=AsyncMock)
+    async def test_row_deleted_before_work_executes(self, mock_tool_loop, _mock_update):
+        from spare_paw.cron.executor import execute_cron
+
+        events: list[str] = []
+        mock_db = _make_mock_db({"metadata": '{"once": true}'}, events=events)
+
+        async def record_work(*args, **kwargs):
+            events.append("work")
+            return "one-shot result"
+
+        mock_tool_loop.side_effect = record_work
 
         app_state = _make_app_state()
         app_state.scheduler = AsyncMock()
 
-        with patch("spare_paw.cron.executor.get_db", return_value=mock_db):
-            await _maybe_delete_once(app_state, "cron-repeat")
+        with patch("spare_paw.cron.executor.get_db", AsyncMock(return_value=mock_db)):
+            await execute_cron(app_state, "cron-once", "do it", None, None)
 
-        # Only the SELECT should have been called, no DELETE
-        calls_str = str(mock_db.execute.call_args_list)
-        assert "DELETE" not in calls_str
+        assert "delete" in events and "work" in events, events
+        assert events.index("delete") < events.index("work"), events
+
+    @pytest.mark.asyncio
+    @patch("spare_paw.cron.executor._update_cron_result", new_callable=AsyncMock)
+    @patch("spare_paw.cron.executor.run_tool_loop", new_callable=AsyncMock)
+    async def test_skipped_when_row_already_gone(self, mock_tool_loop, _mock_update):
+        """If the cron row is already gone (consumed or deleted), do not execute."""
+        from spare_paw.cron.executor import execute_cron
+
+        mock_db = _make_mock_db(None)
+        app_state = _make_app_state()
+        app_state.scheduler = AsyncMock()
+
+        with patch("spare_paw.cron.executor.get_db", AsyncMock(return_value=mock_db)):
+            await execute_cron(app_state, "cron-gone", "do it", None, None)
+
+        mock_tool_loop.assert_not_awaited()
+        app_state.backend.send_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("spare_paw.cron.executor._update_cron_result", new_callable=AsyncMock)
+    @patch("spare_paw.cron.executor.run_tool_loop", new_callable=AsyncMock)
+    async def test_skipped_when_claim_loses_race(self, mock_tool_loop, _mock_update):
+        """If the DELETE claims no row, another run owns the job — skip."""
+        from spare_paw.cron.executor import execute_cron
+
+        mock_db = _make_mock_db({"metadata": '{"once": true}'}, rowcount=0)
+        app_state = _make_app_state()
+        app_state.scheduler = AsyncMock()
+
+        with patch("spare_paw.cron.executor.get_db", AsyncMock(return_value=mock_db)):
+            await execute_cron(app_state, "cron-raced", "do it", None, None)
+
+        mock_tool_loop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("spare_paw.cron.executor._update_cron_result", new_callable=AsyncMock)
+    @patch("spare_paw.cron.executor.run_tool_loop", new_callable=AsyncMock)
+    async def test_scheduler_cleanup_runs_even_on_failure(self, mock_tool_loop, _mock_update):
+        """The scheduler.remove_job cleanup stays in a finally block."""
+        from spare_paw.cron.executor import execute_cron
+
+        mock_db = _make_mock_db({"metadata": '{"once": true}'})
+        mock_tool_loop.side_effect = RuntimeError("model exploded")
+
+        app_state = _make_app_state()
+        app_state.scheduler = AsyncMock()
+
+        with patch("spare_paw.cron.executor.get_db", AsyncMock(return_value=mock_db)):
+            await execute_cron(app_state, "cron-once-f", "do it", None, None)
+
+        app_state.scheduler.remove_job.assert_awaited_once_with("cron-once-f")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -583,3 +583,199 @@ class TestVisionPreprocessing:
 
         for m in assembled:
             assert isinstance(m["content"], str), f"Found multimodal content block: {m}"
+
+
+# ---------------------------------------------------------------------------
+# Robustness audit fixes
+# ---------------------------------------------------------------------------
+
+import pytest_asyncio  # noqa: E402
+from unittest.mock import patch as _patch  # noqa: E402,F401
+
+from spare_paw.core import engine as engine_mod  # noqa: E402
+from spare_paw.core.voice import VoiceTranscriptionError  # noqa: E402
+from spare_paw.router.tool_loop import ToolLoopResult  # noqa: E402
+
+
+def _patch_ctx(mock_ctx):
+    mock_ctx.get_or_create_conversation = AsyncMock(return_value="conv-1")
+    mock_ctx.ingest = AsyncMock(return_value="msg-1")
+    mock_ctx.assemble = AsyncMock(return_value=[{"role": "system", "content": "s"}])
+    mock_ctx.get_conversation_meta = AsyncMock(return_value={})
+    mock_ctx.set_conversation_meta = AsyncMock()
+
+
+class TestVoiceFailureNotice:
+    @pytest.mark.asyncio
+    async def test_transcription_failure_notifies_user(self):
+        """A failed transcription must not be a silent drop."""
+        app_state = _make_app_state()
+        backend = _make_backend()
+        msg = IncomingMessage(voice_bytes=b"\x00\x01")
+
+        with patch("spare_paw.core.engine.voice_module") as mock_voice, \
+             patch("spare_paw.core.engine.run_tool_loop", new_callable=AsyncMock) as mock_loop:
+            mock_voice.transcribe = AsyncMock(side_effect=VoiceTranscriptionError("bad audio"))
+            await process_message(app_state, msg, backend)
+
+        backend.send_text.assert_awaited()
+        notice = backend.send_text.await_args.args[0]
+        assert "transcribe" in notice.lower() or "voice" in notice.lower()
+        mock_loop.assert_not_awaited()
+
+
+class TestFailedOutcomeHandling:
+    @pytest.mark.asyncio
+    async def test_failed_outcome_not_ingested_as_assistant(self):
+        """Loop failures must not be recorded as assistant replies in history."""
+        app_state = _make_app_state()
+        backend = _make_backend()
+        msg = IncomingMessage(text="hello")
+
+        failed = ToolLoopResult(
+            text="LLM call timed out after 120s. Try again.",
+            outcome="llm_timeout",
+            usage={},
+        )
+
+        with patch("spare_paw.core.engine.ctx_module") as mock_ctx, \
+             patch("spare_paw.core.engine.run_tool_loop", new_callable=AsyncMock, return_value=failed), \
+             patch("spare_paw.core.engine.build_system_prompt", new_callable=AsyncMock, return_value="sys"), \
+             patch("spare_paw.core.engine.compact_with_retry", new_callable=AsyncMock):
+            _patch_ctx(mock_ctx)
+            await process_message(app_state, msg, backend)
+
+        ingested_roles = [c.args[1] for c in mock_ctx.ingest.await_args_list]
+        assert "assistant" not in ingested_roles
+        backend.send_text.assert_awaited()
+        sent = backend.send_text.await_args.args[0]
+        assert "timed out" in sent
+
+
+class TestSynthesisCannotSpawn:
+    @pytest.mark.asyncio
+    async def test_agent_callback_synthesis_excludes_spawn_agent(self):
+        """Callback synthesis must not be able to spawn more agents (unbounded chains)."""
+        app_state = _make_app_state()
+        backend = _make_backend()
+        app_state.tool_registry.get_schemas.return_value = [
+            {"type": "function", "function": {"name": "spawn_agent"}},
+            {"type": "function", "function": {"name": "shell"}},
+        ]
+
+        with patch("spare_paw.core.engine.ctx_module") as mock_ctx, \
+             patch("spare_paw.core.engine.run_tool_loop", new_callable=AsyncMock, return_value="synth") as mock_loop, \
+             patch("spare_paw.core.engine.build_system_prompt", new_callable=AsyncMock, return_value="sys"):
+            _patch_ctx(mock_ctx)
+            await process_agent_callback(app_state, "[AGENT_RESULTS] done", backend)
+
+        tools = mock_loop.await_args.kwargs["tools"]
+        names = {t["function"]["name"] for t in tools}
+        assert "spawn_agent" not in names
+        assert "shell" in names
+
+
+class TestQueueItemHandling:
+    @pytest.mark.asyncio
+    async def test_message_timeout_notifies_user(self):
+        """A single stuck message must not silently block the queue forever."""
+        app_state = _make_app_state()
+        app_state.config.get = lambda key, default=None: {
+            "agent.message_timeout_seconds": 0.05,
+        }.get(key, default)
+        backend = _make_backend()
+        msg = IncomingMessage(text="slow")
+
+        async def hang(*args, **kwargs):
+            await asyncio.sleep(10)
+
+        with patch("spare_paw.core.engine.process_message", side_effect=hang):
+            await engine_mod._handle_queue_item(app_state, msg, backend)
+
+        backend.send_text.assert_awaited()
+        sent = backend.send_text.await_args.args[0]
+        assert "long" in sent.lower() or "timed out" in sent.lower()
+
+    def test_queue_healthy_reports_dead_task(self):
+        class _DoneTask:
+            def done(self):
+                return True
+
+        old = engine_mod._queue_task
+        try:
+            engine_mod._queue_task = None
+            assert engine_mod.queue_healthy() is True
+            engine_mod._queue_task = _DoneTask()
+            assert engine_mod.queue_healthy() is False
+        finally:
+            engine_mod._queue_task = old
+
+
+@pytest_asyncio.fixture
+async def _tmp_engine_db(tmp_path):
+    import spare_paw.db as db_mod
+
+    tmp_db_dir = tmp_path / ".spare-paw"
+    tmp_db_dir.mkdir()
+    with patch.object(db_mod, "DB_DIR", tmp_db_dir), \
+         patch.object(db_mod, "DB_PATH", tmp_db_dir / "spare-paw.db"):
+        db_mod._connection = None
+        await db_mod.init_db()
+        yield db_mod
+        await db_mod.close_db()
+
+
+class TestRecovery:
+    @pytest.mark.asyncio
+    async def test_recover_orphans_marks_interrupted_and_requeues(self, _tmp_engine_db):
+        db = await _tmp_engine_db.get_db()
+        await db.execute(
+            "INSERT INTO agents (id, name, status, created_at) VALUES (?, ?, ?, ?)",
+            ("orph1", "orphaned-agent", "running", "2026-01-01T00:00:00+00:00"),
+        )
+        await db.execute(
+            "INSERT INTO agent_callbacks (group_id, payload, delivered, created_at) "
+            "VALUES (?, ?, 0, ?)",
+            ("g1", "[AGENT_RESULTS] pending", "2026-01-01T00:00:00+00:00"),
+        )
+        await db.commit()
+
+        app_state = _make_app_state()
+        backend = _make_backend()
+        old_queue = engine_mod._message_queue
+        engine_mod._message_queue = asyncio.Queue()
+        try:
+            await engine_mod.recover_orphans(app_state, backend)
+
+            async with db.execute("SELECT status FROM agents WHERE id = 'orph1'") as cur:
+                row = await cur.fetchone()
+            assert row["status"] == "interrupted"
+
+            backend.send_text.assert_awaited()
+            notice = backend.send_text.await_args.args[0]
+            assert "orphaned-agent" in notice
+
+            item = engine_mod._message_queue.get_nowait()
+            assert item[0] == "agent_callback"
+            assert item[1] == "[AGENT_RESULTS] pending"
+        finally:
+            engine_mod._message_queue = old_queue
+
+    @pytest.mark.asyncio
+    async def test_mark_callback_delivered(self, _tmp_engine_db):
+        db = await _tmp_engine_db.get_db()
+        cur = await db.execute(
+            "INSERT INTO agent_callbacks (group_id, payload, delivered, created_at) "
+            "VALUES (?, ?, 0, ?)",
+            ("g2", "payload", "2026-01-01T00:00:00+00:00"),
+        )
+        await db.commit()
+        cb_id = cur.lastrowid
+
+        await engine_mod._mark_callback_delivered(cb_id)
+
+        async with db.execute(
+            "SELECT delivered FROM agent_callbacks WHERE id = ?", (cb_id,)
+        ) as cur2:
+            row = await cur2.fetchone()
+        assert row["delivered"] == 1

--- a/tests/test_lcm.py
+++ b/tests/test_lcm.py
@@ -277,6 +277,88 @@ async def test_compact_preserves_fresh_tail(_init_db):
     config_mod.set_override("context.fresh_tail_count", 32)
 
 
+async def _insert_corrupt_summary_node(conn, conversation_id: str, node_id: str) -> None:
+    """Insert a summary node with garbage (non-JSON) in source_msg_ids."""
+    now = datetime.now(timezone.utc).isoformat()
+    await conn.execute(
+        """INSERT INTO summary_nodes
+           (id, conversation_id, parent_id, depth, content, token_count, source_msg_ids, created_at)
+           VALUES (?, ?, NULL, 0, ?, 10, ?, ?)""",
+        (node_id, conversation_id, "Corrupted node content", "{not valid json", now),
+    )
+    await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_compact_skips_corrupt_source_msg_ids(_init_db):
+    """A summary node with corrupt source_msg_ids JSON must not crash compact()."""
+    from spare_paw.config import config as config_mod
+    from spare_paw.context import compact
+
+    config_mod.set_override("context.fresh_tail_count", 10)
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    await _insert_corrupt_summary_node(conn, conv_id, "corrupt-node")
+
+    for i in range(30):
+        await ingest(conv_id, "user", f"Message number {i} about various topics")
+
+    mock_client = _make_mock_router_client("Summary of old messages.")
+
+    # Must not raise — the corrupt row is treated as covering no messages
+    await compact(conv_id, mock_client, "test-model")
+
+    # Compaction still proceeds and creates fresh leaf summaries
+    async with conn.execute(
+        "SELECT COUNT(*) FROM summary_nodes WHERE conversation_id = ? AND depth = 0 AND id != 'corrupt-node'",
+        (conv_id,),
+    ) as cur:
+        count = (await cur.fetchone())[0]
+    assert count > 0
+
+    config_mod.set_override("context.fresh_tail_count", 32)
+
+
+@pytest.mark.asyncio
+async def test_lcm_expand_handles_corrupt_source_msg_ids(_init_db):
+    """lcm_expand must not crash on a node with corrupt source_msg_ids JSON."""
+    from spare_paw.tools.lcm_tools import _handle_lcm_expand
+
+    conn = _init_db
+    conv_id = await new_conversation()
+    await _insert_corrupt_summary_node(conn, conv_id, "corrupt-expand-node")
+
+    result_json = await _handle_lcm_expand(summary_id="corrupt-expand-node")
+    result = json.loads(result_json)
+
+    assert result.get("messages") == []
+    assert result.get("total_source_messages") == 0
+
+
+@pytest.mark.asyncio
+async def test_lcm_describe_handles_corrupt_source_msg_ids(_init_db):
+    """lcm_describe must not crash when one node has corrupt source_msg_ids JSON."""
+    from spare_paw.tools.lcm_tools import _handle_lcm_describe
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    await _insert_summary_node(
+        conn, conv_id, "A healthy summary", node_id="good-node", source_msg_ids=["m1", "m2"],
+    )
+    await _insert_corrupt_summary_node(conn, conv_id, "corrupt-describe-node")
+
+    result_json = await _handle_lcm_describe(conversation_id=conv_id)
+    result = json.loads(result_json)
+
+    assert result["count"] == 2
+    by_id = {s["id"]: s for s in result["summaries"]}
+    assert by_id["good-node"]["source_msg_ids"] == ["m1", "m2"]
+    assert by_id["corrupt-describe-node"]["source_msg_ids"] == []
+
+
 # ---------------------------------------------------------------------------
 # Assembly tests
 # ---------------------------------------------------------------------------

--- a/tests/test_lcm_compaction.py
+++ b/tests/test_lcm_compaction.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiosqlite
@@ -123,6 +124,66 @@ async def test_source_messages_preserved_on_failure(_init_db):
 
 
 @pytest.mark.asyncio
+async def test_condense_failure_leaves_no_orphaned_node(_init_db, monkeypatch):
+    """A crash between the condensed-node INSERT and the leaf UPDATEs must roll back.
+
+    Without an explicit transaction, the pending INSERT would be persisted by
+    the next unrelated commit on the shared connection, leaving an orphaned
+    condensed node whose leaves don't point to it.
+    """
+    from spare_paw.context import _condense_summaries
+
+    conn = _init_db
+    conv_id = await new_conversation()
+
+    # Pre-create 4 orphan leaves (enough to trigger condensation)
+    now = datetime.now(timezone.utc).isoformat()
+    for i in range(4):
+        await conn.execute(
+            """INSERT INTO summary_nodes
+               (id, conversation_id, parent_id, depth, content, token_count, source_msg_ids, created_at)
+               VALUES (?, ?, NULL, 0, ?, 10, '[]', ?)""",
+            (f"leaf-{i}", conv_id, f"Leaf summary {i}", now),
+        )
+    await conn.commit()
+
+    mock_client = _make_mock_router_client("Condensed summary.")
+
+    # Fail on the first parent-pointer UPDATE (i.e. right after the INSERT)
+    real_execute = conn.execute
+
+    def failing_execute(sql, *args, **kwargs):
+        if sql.lstrip().startswith("UPDATE summary_nodes SET parent_id"):
+            raise RuntimeError("simulated crash between INSERT and UPDATE")
+        return real_execute(sql, *args, **kwargs)
+
+    monkeypatch.setattr(conn, "execute", failing_execute)
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        await _condense_summaries(conv_id, mock_client, "test-model")
+
+    monkeypatch.undo()
+
+    # Simulate a later unrelated commit on the shared connection
+    await conn.commit()
+
+    async with conn.execute(
+        "SELECT COUNT(*) FROM summary_nodes WHERE conversation_id = ? AND depth = 1",
+        (conv_id,),
+    ) as cur:
+        orphaned = (await cur.fetchone())[0]
+    assert orphaned == 0, "Failed condensation must not leave an orphaned condensed node"
+
+    # All leaves must still be parentless (available for the next condensation)
+    async with conn.execute(
+        "SELECT COUNT(*) FROM summary_nodes WHERE conversation_id = ? AND depth = 0 AND parent_id IS NULL",
+        (conv_id,),
+    ) as cur:
+        leaves = (await cur.fetchone())[0]
+    assert leaves == 4
+
+
+@pytest.mark.asyncio
 async def test_consecutive_failure_counter_increments(_init_db):
     """Each double-failure cycle should increment the consecutive failure counter."""
     from spare_paw.config import config as config_mod
@@ -172,8 +233,8 @@ async def test_consecutive_failure_counter_resets_on_success(_init_db):
 
 
 @pytest.mark.asyncio
-async def test_warning_fires_after_three_consecutive_failures(_init_db):
-    """A distinct WARNING should be logged after 3+ consecutive failures."""
+async def test_error_escalation_at_consecutive_failure_threshold(_init_db):
+    """A distinct ERROR should be logged once failures reach the escalation threshold."""
     import logging
     from spare_paw.config import config as config_mod
 
@@ -186,31 +247,41 @@ async def test_warning_fires_after_three_consecutive_failures(_init_db):
     mock_client = _make_mock_router_client()
     mock_client.chat.side_effect = Exception("always fails")
 
-    warning_messages: list[str] = []
+    error_messages: list[str] = []
 
     class CapturingHandler(logging.Handler):
         def emit(self, record: logging.LogRecord) -> None:
-            if record.levelno == logging.WARNING:
-                warning_messages.append(record.getMessage())
+            if record.levelno == logging.ERROR:
+                error_messages.append(record.getMessage())
 
     handler = CapturingHandler()
     ctx_logger = logging.getLogger("spare_paw.context")
     ctx_logger.addHandler(handler)
 
+    threshold = ctx_mod._COMPACT_FAILURE_ESCALATION_THRESHOLD
+
+    def _escalations() -> list[str]:
+        return [m for m in error_messages if "times consecutively" in m]
+
     try:
-        for _ in range(3):
+        # Below the threshold: no escalation yet
+        for _ in range(threshold - 1):
             with patch("asyncio.sleep", new_callable=AsyncMock):
                 await compact_with_retry(conv_id, mock_client, "test-model")
+        assert _escalations() == [], "Escalation must not fire below the threshold"
+
+        # The failure cycle that reaches the threshold triggers the escalation
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await compact_with_retry(conv_id, mock_client, "test-model")
     finally:
         ctx_logger.removeHandler(handler)
 
-    threshold_warnings = [
-        m for m in warning_messages if "3+ times consecutively" in m
-    ]
-    assert len(threshold_warnings) >= 1, (
-        "Expected a WARNING about 3+ consecutive failures, got: " + str(warning_messages)
+    escalations = _escalations()
+    assert len(escalations) == 1, (
+        "Expected exactly one escalation ERROR at the threshold, got: " + str(error_messages)
     )
+    assert str(threshold) in escalations[0], "Escalation must include the failure count"
 
-    assert ctx_mod._compact_consecutive_failures.get(conv_id, 0) == 3
+    assert ctx_mod._compact_consecutive_failures.get(conv_id, 0) == threshold
 
     config_mod.set_override("context.fresh_tail_count", 32)

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -18,12 +18,17 @@ import spare_paw.tools.subagent as subagent_mod
 
 @pytest.fixture(autouse=True)
 def _reset_agents():
-    """Clear the global _agents and _channels dicts before each test."""
-    subagent_mod._agents.clear()
-    subagent_mod._channels.clear()
+    """Clear the global _agents/_channels dicts and notification claims before each test."""
+    def _clear() -> None:
+        subagent_mod._agents.clear()
+        subagent_mod._channels.clear()
+        getattr(subagent_mod, "_notified_groups", set()).clear()
+        if hasattr(subagent_mod, "_shutting_down"):
+            subagent_mod._shutting_down = False
+
+    _clear()
     yield
-    subagent_mod._agents.clear()
-    subagent_mod._channels.clear()
+    _clear()
 
 
 def _make_app_state() -> MagicMock:
@@ -851,12 +856,14 @@ async def test_tool_loop_to_spawn_handler_integration():
         }]
     }
 
-    mock_client = MagicMock()
-    mock_client.chat = AsyncMock(return_value=batch_response)
+    from tests._stream_helpers import FakeStreamingClient, response_dict_to_chunks
+
+    # spawn_agent returns __stop_turn__, so the loop ends after this batch.
+    client = FakeStreamingClient([response_dict_to_chunks(batch_response)])
 
     with patch.object(subagent_mod, "_run_agent", side_effect=_noop_run_agent):
         await run_tool_loop(
-            client=mock_client,
+            client=client,
             messages=[{"role": "user", "content": "do two things"}],
             model="m",
             tools=registry.get_schemas(),
@@ -1546,3 +1553,258 @@ async def test_notify_formats_structured_results():
     assert "What is the budget?" in synthetic
 
     subagent_mod._message_queue = None
+
+
+# ---------------------------------------------------------------------------
+# Robustness audit fixes
+# ---------------------------------------------------------------------------
+
+import pytest_asyncio  # noqa: E402
+
+from spare_paw.router.tool_loop import ToolLoopResult  # noqa: E402
+
+
+def _completed_agent(name: str, group_id: str) -> dict:
+    return {
+        "name": name,
+        "status": "completed",
+        "group_id": group_id,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "result": "raw",
+        "parsed_result": {
+            "status": "complete",
+            "summary": f"{name} done",
+            "findings": [],
+            "sources": [],
+        },
+    }
+
+
+class TestSingleFlightGroupNotification:
+    @pytest.mark.asyncio
+    async def test_concurrent_group_completion_notifies_once(self):
+        """Two agents finishing simultaneously must produce exactly one callback."""
+        queue: asyncio.Queue = asyncio.Queue()
+        subagent_mod._message_queue = queue
+        subagent_mod._agents["g1a"] = _completed_agent("g1a", "grp-race")
+        subagent_mod._agents["g1b"] = _completed_agent("g1b", "grp-race")
+
+        await asyncio.gather(
+            subagent_mod._maybe_notify_group("grp-race"),
+            subagent_mod._maybe_notify_group("grp-race"),
+        )
+
+        assert queue.qsize() == 1
+        subagent_mod._message_queue = None
+
+    @pytest.mark.asyncio
+    async def test_incomplete_group_is_not_notified(self):
+        queue: asyncio.Queue = asyncio.Queue()
+        subagent_mod._message_queue = queue
+        subagent_mod._agents["g2a"] = _completed_agent("g2a", "grp-partial")
+        running = _completed_agent("g2b", "grp-partial")
+        running["status"] = "running"
+        subagent_mod._agents["g2b"] = running
+
+        await subagent_mod._maybe_notify_group("grp-partial")
+
+        assert queue.qsize() == 0
+        subagent_mod._message_queue = None
+
+
+class TestOutcomeMapping:
+    @pytest.mark.asyncio
+    async def test_llm_timeout_outcome_marks_agent_failed(self):
+        """A loop-level failure must NOT be reported as a completed agent."""
+        app_state = _make_app_state()
+        agent_id = "fail-map"
+        subagent_mod._agents[agent_id] = {
+            "name": "mapper",
+            "prompt": "test",
+            "status": "starting",
+            "group_id": None,
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+
+        fake = ToolLoopResult(
+            text="LLM call timed out after 120s. Try again.",
+            outcome="llm_timeout",
+            usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        )
+
+        with patch("spare_paw.router.tool_loop.run_tool_loop", return_value=fake):
+            with patch("spare_paw.core.prompt.build_subagent_prompt", return_value="sys"):
+                await subagent_mod._run_agent(
+                    agent_id, "test", app_state,
+                    model=None, tools_filter=None, max_iterations=5,
+                )
+
+        agent = subagent_mod._agents[agent_id]
+        assert agent["status"] == "failed"
+        assert "llm_timeout" in agent["error"]
+
+
+class TestSpawnHardening:
+    @pytest.mark.asyncio
+    async def test_spawn_clamps_max_iterations(self):
+        app_state = _make_app_state()
+        captured: dict = {}
+
+        async def fake_run_agent(agent_id, prompt, app_state, model, tools_filter,
+                                 max_iterations, system_suffix=None, tool_limits=None):
+            captured["max_iterations"] = max_iterations
+
+        with patch.object(subagent_mod, "_run_agent", side_effect=fake_run_agent):
+            await subagent_mod._handle_spawn(app_state, name="x", prompt="y", max_iterations=5000)
+            await asyncio.sleep(0)
+
+        assert captured["max_iterations"] <= 30
+
+    @pytest.mark.asyncio
+    async def test_spawn_survives_progress_send_failure(self):
+        """A failed Telegram progress message must not fail the spawn (duplicate-agent risk)."""
+        app_state = _make_app_state()
+
+        class _Backend:
+            async def send_progress(self, text):
+                raise RuntimeError("telegram down")
+
+        app_state.backend = _Backend()
+
+        with patch.object(subagent_mod, "_run_agent", side_effect=_noop_run_agent):
+            result = json.loads(
+                await subagent_mod._handle_spawn(app_state, name="x", prompt="y")
+            )
+
+        assert "agent_id" in result
+        assert result["__stop_turn__"] is True
+
+
+class TestArchetypeLeastPrivilege:
+    def test_researcher_has_no_shell_or_files(self):
+        """Web-facing agents must not combine untrusted content with shell access."""
+        tools = subagent_mod.AGENT_TYPES["researcher"]["tools"]
+        assert "shell" not in tools
+        assert "files" not in tools
+
+    def test_browser_has_no_shell_or_files(self):
+        tools = subagent_mod.AGENT_TYPES["browser"]["tools"]
+        assert "shell" not in tools
+        assert "files" not in tools
+
+
+@pytest_asyncio.fixture
+async def _tmp_agents_db(tmp_path):
+    """Isolated DB with the agents/agent_callbacks schema applied."""
+    import spare_paw.db as db_mod
+
+    tmp_db_dir = tmp_path / ".spare-paw"
+    tmp_db_dir.mkdir()
+    with patch.object(db_mod, "DB_DIR", tmp_db_dir), \
+         patch.object(db_mod, "DB_PATH", tmp_db_dir / "spare-paw.db"):
+        db_mod._connection = None
+        await db_mod.init_db()
+        yield db_mod
+        await db_mod.close_db()
+
+
+class TestAgentPersistence:
+    @pytest.mark.asyncio
+    async def test_spawn_persists_agent_row(self, _tmp_agents_db):
+        app_state = _make_app_state()
+
+        with patch.object(subagent_mod, "_run_agent", side_effect=_noop_run_agent):
+            result = json.loads(
+                await subagent_mod._handle_spawn(app_state, name="persisted", prompt="task")
+            )
+
+        db = await _tmp_agents_db.get_db()
+        async with db.execute(
+            "SELECT name, status FROM agents WHERE id = ?", (result["agent_id"],)
+        ) as cur:
+            row = await cur.fetchone()
+
+        assert row is not None
+        assert row["name"] == "persisted"
+
+    @pytest.mark.asyncio
+    async def test_completion_updates_persisted_status(self, _tmp_agents_db):
+        app_state = _make_app_state()
+        agent_id = "persist-done"
+        subagent_mod._agents[agent_id] = {
+            "name": "finisher",
+            "prompt": "test",
+            "status": "starting",
+            "group_id": None,
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+
+        fake = ToolLoopResult(
+            text=json.dumps({"status": "complete", "summary": "ok",
+                             "findings": [], "sources": []}),
+            outcome="ok",
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        )
+
+        with patch("spare_paw.router.tool_loop.run_tool_loop", return_value=fake):
+            with patch("spare_paw.core.prompt.build_subagent_prompt", return_value="sys"):
+                await subagent_mod._run_agent(
+                    agent_id, "test", app_state,
+                    model=None, tools_filter=None, max_iterations=5,
+                )
+
+        db = await _tmp_agents_db.get_db()
+        async with db.execute(
+            "SELECT status FROM agents WHERE id = ?", (agent_id,)
+        ) as cur:
+            row = await cur.fetchone()
+
+        assert row is not None
+        assert row["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_callback_persisted_before_enqueue(self, _tmp_agents_db):
+        queue: asyncio.Queue = asyncio.Queue()
+        subagent_mod._message_queue = queue
+        subagent_mod._agents["cb1"] = _completed_agent("cb1", "grp-cb")
+
+        await subagent_mod._notify_main_agent("grp-cb")
+
+        db = await _tmp_agents_db.get_db()
+        async with db.execute(
+            "SELECT id, delivered, payload FROM agent_callbacks"
+        ) as cur:
+            rows = await cur.fetchall()
+
+        assert len(rows) == 1
+        assert rows[0]["delivered"] == 0
+        assert "cb1 done" in rows[0]["payload"]
+
+        item = queue.get_nowait()
+        assert item[0] == "agent_callback"
+        assert item[2] == rows[0]["id"]
+        subagent_mod._message_queue = None
+
+
+class TestSubagentBudgetWiring:
+    @pytest.mark.asyncio
+    async def test_run_agent_passes_token_budget(self):
+        app_state = _make_app_state()
+        agent_id = "budget-1"
+        subagent_mod._agents[agent_id] = {
+            "name": "budgeted",
+            "prompt": "test",
+            "status": "starting",
+            "group_id": None,
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+
+        fake = ToolLoopResult(text="{}", outcome="ok", usage={})
+        with patch("spare_paw.router.tool_loop.run_tool_loop", return_value=fake) as mock_loop:
+            with patch("spare_paw.core.prompt.build_subagent_prompt", return_value="sys"):
+                await subagent_mod._run_agent(
+                    agent_id, "test", app_state,
+                    model=None, tools_filter=None, max_iterations=5,
+                )
+
+        assert mock_loop.await_args.kwargs.get("token_budget", 0) > 0

--- a/tests/test_telegram_backend.py
+++ b/tests/test_telegram_backend.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import re
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
+from telegram.error import NetworkError, TimedOut
 
 from spare_paw.backend import MessageBackend
 from spare_paw.bot.backend import TelegramBackend, md_to_html
@@ -242,6 +245,76 @@ class TestSendText:
         call_kwargs = bot.send_message.call_args
         text = call_kwargs.kwargs.get("text", call_kwargs[1].get("text", ""))
         assert text  # should send non-empty fallback
+
+
+class TestSendRetry:
+    @pytest.mark.asyncio
+    async def test_send_text_retries_on_network_error(self, monkeypatch):
+        backend, bot = _make_backend()
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+        # Fail twice with a transient network error, then succeed.
+        bot.send_message.side_effect = [
+            NetworkError("connection reset"),
+            NetworkError("connection reset"),
+            None,
+        ]
+        await backend.send_text("hello")
+        assert bot.send_message.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_send_text_backoff_delays(self, monkeypatch):
+        backend, bot = _make_backend()
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+        bot.send_message.side_effect = [
+            TimedOut(),
+            TimedOut(),
+            TimedOut(),
+            TimedOut(),
+            None,
+        ]
+        await backend.send_text("hello")
+        sleep_mock.assert_has_awaits([call(1.0), call(2.0)])
+
+    @pytest.mark.asyncio
+    async def test_send_text_raises_after_exhausted_retries(self, monkeypatch, caplog):
+        backend, bot = _make_backend()
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        bot.send_message.side_effect = NetworkError("network down")
+        with caplog.at_level(logging.ERROR, logger="spare_paw.bot.backend"):
+            with pytest.raises(NetworkError):
+                await backend.send_text("hello")
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert errors, "expected an ERROR log on final delivery failure"
+        assert any("5" in r.getMessage() for r in errors), "ERROR log should include chunk length"
+
+    @pytest.mark.asyncio
+    async def test_send_text_html_fallback_still_works(self, monkeypatch):
+        backend, bot = _make_backend()
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        # Non-network error on HTML send falls back to plain within one attempt.
+        bot.send_message.side_effect = [Exception("can't parse entities"), None]
+        await backend.send_text("hello")
+        assert bot.send_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_voice_retries_on_timeout(self, monkeypatch):
+        backend, bot = _make_backend()
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        bot.send_voice.side_effect = [TimedOut(), None]
+        await backend.send_voice(b"OggS fake voice data")
+        assert bot.send_voice.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_file_retries_on_network_error(self, monkeypatch, tmp_path):
+        backend, bot = _make_backend()
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        photo = tmp_path / "photo.jpg"
+        photo.write_bytes(b"\xff\xd8\xff")
+        bot.send_photo.side_effect = [NetworkError("connection reset"), None]
+        await backend.send_file(str(photo))
+        assert bot.send_photo.call_count == 2
 
 
 class TestSendFile:

--- a/tests/test_tool_event.py
+++ b/tests/test_tool_event.py
@@ -7,34 +7,30 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from spare_paw.router.openrouter import StreamChunk
 from spare_paw.router.tool_loop import DEFAULT_TOOL_LIMITS, ToolEvent, run_tool_loop
+from tests._stream_helpers import FakeStreamingClient, response_to_chunks
 
 
-def _text_response(content: str = "done") -> dict:
-    return {
-        "choices": [{"message": {"role": "assistant", "content": content}}],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-    }
+def _text_chunks(content: str = "done") -> list[StreamChunk]:
+    return response_to_chunks(
+        content=content,
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
 
 
-def _tool_call_response(name: str, arguments: dict, call_id: str = "call_1") -> dict:
-    return {
-        "choices": [{
-            "message": {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [{
-                    "id": call_id,
-                    "type": "function",
-                    "function": {
-                        "name": name,
-                        "arguments": json.dumps(arguments),
-                    },
-                }],
-            }
+def _tool_call_chunks(name: str, arguments: dict, call_id: str = "call_1") -> list[StreamChunk]:
+    return response_to_chunks(
+        tool_calls=[{
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": name,
+                "arguments": json.dumps(arguments),
+            },
         }],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-    }
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
 
 
 class TestToolEvent:
@@ -59,11 +55,10 @@ class TestOnEventCallback:
         events: list[ToolEvent] = []
         on_event = MagicMock(side_effect=lambda e: events.append(e))
 
-        mock_client = AsyncMock()
-        mock_client.chat = AsyncMock(return_value=_text_response("hi"))
+        client = FakeStreamingClient([_text_chunks("hi")])
 
         await run_tool_loop(
-            client=mock_client,
+            client=client,
             messages=[{"role": "user", "content": "hello"}],
             model="m",
             tools=[],
@@ -81,16 +76,15 @@ class TestOnEventCallback:
         events: list[ToolEvent] = []
         on_event = MagicMock(side_effect=lambda e: events.append(e))
 
-        mock_client = AsyncMock()
-        mock_client.chat = AsyncMock(side_effect=[
-            _tool_call_response("shell", {"command": "ls"}),
-            _text_response("done"),
+        client = FakeStreamingClient([
+            _tool_call_chunks("shell", {"command": "ls"}),
+            _text_chunks("done"),
         ])
         mock_registry = AsyncMock()
         mock_registry.execute = AsyncMock(return_value="file_list")
 
         await run_tool_loop(
-            client=mock_client,
+            client=client,
             messages=[{"role": "user", "content": "list"}],
             model="m",
             tools=[{"type": "function", "function": {"name": "shell"}}],
@@ -108,11 +102,10 @@ class TestOnEventCallback:
     @pytest.mark.asyncio
     async def test_no_event_callback_is_safe(self):
         """on_event=None should not cause errors."""
-        mock_client = AsyncMock()
-        mock_client.chat = AsyncMock(return_value=_text_response("hi"))
+        client = FakeStreamingClient([_text_chunks("hi")])
 
         result = await run_tool_loop(
-            client=mock_client,
+            client=client,
             messages=[],
             model="m",
             tools=[],
@@ -124,16 +117,23 @@ class TestOnEventCallback:
 
 class TestOnTokenCallback:
     @pytest.mark.asyncio
-    async def test_fires_tokens_for_final_text(self):
-        """on_token receives word-chunked tokens of the final response."""
+    async def test_fires_tokens_for_streamed_deltas(self):
+        """on_token receives each text delta of the final response as streamed."""
         tokens: list[str] = []
         on_token = MagicMock(side_effect=lambda t: tokens.append(t))
 
-        mock_client = AsyncMock()
-        mock_client.chat = AsyncMock(return_value=_text_response("hello world"))
+        client = FakeStreamingClient([[
+            StreamChunk(kind="text_delta", content="hello "),
+            StreamChunk(kind="text_delta", content="world"),
+            StreamChunk(
+                kind="done",
+                finish_reason="stop",
+                usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            ),
+        ]])
 
         result = await run_tool_loop(
-            client=mock_client,
+            client=client,
             messages=[],
             model="m",
             tools=[],
@@ -142,16 +142,15 @@ class TestOnTokenCallback:
         )
 
         assert result == "hello world"
-        assert tokens == ["hello ", "world "]
+        assert tokens == ["hello ", "world"]
 
     @pytest.mark.asyncio
     async def test_no_token_callback_is_safe(self):
         """on_token=None should not cause errors."""
-        mock_client = AsyncMock()
-        mock_client.chat = AsyncMock(return_value=_text_response("hi"))
+        client = FakeStreamingClient([_text_chunks("hi")])
 
         result = await run_tool_loop(
-            client=mock_client,
+            client=client,
             messages=[],
             model="m",
             tools=[],

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from spare_paw.router.tool_loop import run_tool_loop
+from spare_paw.router.tool_loop import ToolLoopResult, run_tool_loop
 from tests._stream_helpers import FakeStreamingClient, response_to_chunks
 
 
@@ -226,3 +226,147 @@ class TestStructuredLogging:
         warning_logs = [r for r in caplog.records if r.levelno >= logging.WARNING]
         budget_warnings = [r for r in warning_logs if "token" in r.message.lower() and "budget" in r.message.lower()]
         assert len(budget_warnings) > 0
+
+
+class TestStructuredOutcome:
+    """Audit fix: loop failures must be distinguishable from real replies."""
+
+    @pytest.mark.asyncio
+    async def test_ok_outcome(self):
+        client = FakeStreamingClient([_chunks(content="Final answer")])
+        registry = AsyncMock()
+
+        result = await run_tool_loop(
+            client=client,
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[],
+            tool_registry=registry,
+            return_result=True,
+        )
+
+        assert isinstance(result, ToolLoopResult)
+        assert result.outcome == "ok"
+        assert result.text == "Final answer"
+        assert result.usage["total_tokens"] == 15
+
+    @pytest.mark.asyncio
+    async def test_llm_timeout_outcome(self):
+        class _SlowStreamClient:
+            async def chat_stream(self, messages, model, tools=None):
+                await asyncio.sleep(999)
+                if False:  # pragma: no cover — makes this an async generator
+                    yield None
+
+        registry = AsyncMock()
+        result = await run_tool_loop(
+            client=_SlowStreamClient(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[],
+            tool_registry=registry,
+            llm_timeout=0.05,
+            return_result=True,
+        )
+
+        assert result.outcome == "llm_timeout"
+
+    @pytest.mark.asyncio
+    async def test_budget_exhausted_outcome(self):
+        client = FakeStreamingClient([
+            _chunks(
+                tool_calls=[_tool_call_dict("shell", {"command": "x"})],
+                usage={"prompt_tokens": 30000, "completion_tokens": 10000, "total_tokens": 40000},
+            ),
+        ])
+        registry = AsyncMock()
+        registry.execute = AsyncMock(return_value="ok")
+
+        result = await run_tool_loop(
+            client=client,
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "shell"}}],
+            tool_registry=registry,
+            token_budget=30000,
+            return_result=True,
+        )
+
+        assert result.outcome == "budget_exhausted"
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_fallback_error_outcome(self):
+        """When even the final no-tools summary call fails, outcome is max_iterations."""
+        client = FakeStreamingClient([
+            _chunks(tool_calls=[_tool_call_dict("shell", {"command": "x"})]),
+        ])
+        client.chat = AsyncMock(side_effect=RuntimeError("api down"))
+        registry = AsyncMock()
+        registry.execute = AsyncMock(return_value="ok")
+
+        result = await run_tool_loop(
+            client=client,
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "shell"}}],
+            tool_registry=registry,
+            max_iterations=1,
+            return_result=True,
+        )
+
+        assert result.outcome == "max_iterations"
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_with_successful_summary_is_ok(self):
+        """The forced final summary is a legitimate model reply, not an error."""
+        client = FakeStreamingClient([
+            _chunks(tool_calls=[_tool_call_dict("shell", {"command": "x"})]),
+        ])
+        registry = AsyncMock()
+        registry.execute = AsyncMock(return_value="ok")
+
+        result = await run_tool_loop(
+            client=client,
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "shell"}}],
+            tool_registry=registry,
+            max_iterations=1,
+            return_result=True,
+        )
+
+        assert result.outcome == "ok"
+        assert result.text == "fallback"
+
+
+class TestPerToolTimeoutOverrides:
+    @pytest.mark.asyncio
+    async def test_consult_main_gets_extended_timeout(self):
+        """consult_main needs an LLM round-trip; the generic tool timeout must not apply."""
+        client = FakeStreamingClient([
+            _chunks(tool_calls=[_tool_call_dict("consult_main", {"question": "q"})]),
+            _chunks(content="done"),
+        ])
+
+        registry = AsyncMock()
+
+        async def slow_consult(name, args, executor=None):
+            await asyncio.sleep(0.3)
+            return "answer"
+
+        registry.execute = slow_consult
+
+        messages: list[dict] = [{"role": "user", "content": "hi"}]
+        result = await run_tool_loop(
+            client=client,
+            messages=messages,
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "consult_main"}}],
+            tool_registry=registry,
+            tool_timeout=0.05,
+        )
+
+        tool_msgs = [m for m in messages if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert "timed out" not in tool_msgs[0]["content"].lower()
+        assert result == "done"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -213,3 +213,56 @@ class TestFilesTool:
         res = json.loads(await execute_files("write", fpath, content=None, allowed_paths=allowed))
         assert "error" in res
         assert "content" in res["error"].lower()
+
+
+# ===========================================================================
+# Custom tools — execution environment and logging
+# ===========================================================================
+
+
+class TestCustomToolExecution:
+    @staticmethod
+    def _write_script(tmp_path, content: str):
+        script = tmp_path / "tool.sh"
+        script.write_text(content, encoding="utf-8")
+        script.chmod(0o755)
+        return script
+
+    def test_env_does_not_leak_parent_secrets(self, tmp_path, monkeypatch):
+        from spare_paw.tools.custom_tools import _execute_custom_tool
+
+        monkeypatch.setenv("SPARE_PAW_FAKE_SECRET", "sk-supersecretvalue12345")
+        script = self._write_script(tmp_path, "env\n")
+
+        result = json.loads(_execute_custom_tool(str(script)))
+
+        assert result["exit_code"] == 0
+        assert "SPARE_PAW_FAKE_SECRET" not in result["stdout"]
+        assert "sk-supersecretvalue12345" not in result["stdout"]
+        # Allowlisted basics must still be present
+        assert "PATH=" in result["stdout"]
+
+    def test_env_still_passes_tool_params(self, tmp_path):
+        from spare_paw.tools.custom_tools import _execute_custom_tool
+
+        script = self._write_script(tmp_path, 'echo "city=$TOOL_CITY"\n')
+        result = json.loads(_execute_custom_tool(str(script), city="Berlin"))
+
+        assert result["exit_code"] == 0
+        assert "city=Berlin" in result["stdout"]
+
+    def test_param_logging_redacts_secrets(self, tmp_path, caplog):
+        import logging
+
+        from spare_paw.tools.custom_tools import _execute_custom_tool
+
+        secret = "sk-" + "a" * 24
+        script = self._write_script(tmp_path, "true\n")
+
+        with caplog.at_level(logging.INFO, logger="spare_paw.tools.custom_tools"):
+            _execute_custom_tool(str(script), api_key=secret, city="Berlin")
+
+        assert secret not in caplog.text
+        assert "[REDACTED]" in caplog.text
+        # Non-secret params remain visible for debuggability
+        assert "city" in caplog.text


### PR DESCRIPTION
## Summary

Implements all findings from the dependability audit of the subagent architecture and surrounding subsystems. Four workstreams, each landed test-first.

### Orchestration core
- **Restart-safe agents** — new `agents` + `agent_callbacks` tables (schema v4). Agent state persists across restarts; callbacks are written to DB before enqueueing and marked delivered after processing. Startup recovery marks orphaned agents `interrupted`, notifies the user, and re-delivers unprocessed results. Since deploys restart the service, this closes the biggest silent-failure mode.
- **Honest failure reporting** — `run_tool_loop` returns a structured outcome (`ok` / `llm_timeout` / `budget_exhausted` / `max_iterations`). Timed-out subagents are reported failed instead of "completed" with the error text as findings; main-turn failures are sent to the user and never ingested as assistant history; failed voice transcription now gets a reply.
- **Real concurrency** — LLM semaphore raised from 1 to `llm.max_concurrent` (default 4); acquired outside the `llm_timeout` window so queueing doesn't masquerade as API timeouts; `consult_main` gets a 180s per-tool timeout.
- **Bounded agents** — single-flight group notification (fixes duplicate-callback race), synthesis turn cannot spawn agents (no unbounded chains), spawn survives progress-send failures (no duplicate spawns), subagent token budget (150k) + server-side iteration clamp (30), finished agents reaped from memory after 1h.
- **Orderly shutdown & honest liveness** — scheduler → cancel agents (persisted as `interrupted`) → drain queue → close clients/DB; systemd watchdog ping gated on the queue consumer being alive; per-message 600s ceiling with user notice.
- **Least privilege** — researcher/browser archetypes lose `shell`/`files` (untrusted web content + shell = prompt-injection chain).

### Cron
Explicit `misfire_grace_time=3600` / `coalesce` / `max_instances=1` (jobs missed while down run once on restart, no overlaps), explicit timezone via `cron.timezone`, claim-then-run one-shot crons (no double-fire across restarts).

### Persistence
Defensive JSON parsing on all stored blobs (one corrupt row no longer bricks context assembly/compaction), atomic condensation with rollback, compaction-failure escalation to ERROR, clear fail-fast errors on malformed config.yaml.

### Tools & delivery
Telegram sends retry with backoff on transient network errors, custom tools get an allowlist env instead of the full parent environment, browser session lock + Chromium cleanup on failed connect, screenshots moved to private `~/.spare-paw/screenshots` with 7-day cleanup.

### Test infra (incidental)
Fixed `conftest.py` `os._exit` swallowing the entire pytest report when piped; fixed 6 tests silently broken since the streaming refactor (stale `AsyncMock` streaming mocks).

## Behavior changes to note
- Malformed `config.yaml` now fails fast at startup with a clear error.
- First restart after deploying will message the user if any agents were running.

## Test plan
- [x] 632 fast tests pass (`pytest -m "not slow"`)
- [x] 40 slow webhook integration tests pass (`pytest -m slow`)
- [x] `ruff check src/ tests/` clean
- [x] Every fix landed with a failing test written first

🤖 Generated with [Claude Code](https://claude.com/claude-code)